### PR TITLE
XSLT param standard 20.11 de BibLibre

### DIFF
--- a/biblibre/intranet/UNIMARCslim2intranetDetail.xsl
+++ b/biblibre/intranet/UNIMARCslim2intranetDetail.xsl
@@ -1,0 +1,2990 @@
+<xsl:stylesheet version="1.0"
+  xmlns:marc="http://www.loc.gov/MARC21/slim"
+  xmlns:items="http://www.koha-community.org/items"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  exclude-result-prefixes="marc items">
+
+<xsl:import href="UNIMARCslimUtils.xsl"/>
+<xsl:output method = "html" indent="yes" omit-xml-declaration = "yes" encoding="UTF-8"/>
+<xsl:template match="/">
+<xsl:apply-templates/>
+</xsl:template>
+
+<xsl:template match="marc:record">
+<xsl:variable name="Show856uAsImage" select="marc:sysprefs/marc:syspref[@name='Display856uAsImage']"/>
+<xsl:variable name="leader" select="marc:leader"/>
+<xsl:variable name="leader6" select="substring($leader,7,1)"/>
+<xsl:variable name="leader7" select="substring($leader,8,1)"/>
+<xsl:variable name="biblionumber" select="marc:controlfield[@tag=001]"/>
+<xsl:variable name="champ_610" select="marc:datafield[@tag=610]/marc:subfield[@code='a']"/>
+<xsl:variable name="ppn" select="marc:controlfield[@tag=009]"/>
+<xsl:variable name="coverCD" select="marc:datafield[@tag=933]/marc:subfield[@code='a']"/>
+<xsl:variable name="type_doc" select="marc:datafield[@tag=099]/marc:subfield[@code='t']"/>
+<xsl:variable name="renvoi" select="marc:datafield[@tag=700]/@ind1"/>
+
+<div id="num_notice_bib" style="display:none;" ><xsl:value-of select="$biblionumber"/></div>
+
+<xsl:if test="marc:datafield[@tag=200]">
+<xsl:for-each select="marc:datafield[@tag=200]">
+<h1>
+<xsl:call-template name="addClassRtl" />
+<xsl:variable name="title" select="marc:subfield[@code='a']"/>
+<xsl:variable name="ntitle"
+select="translate($title, '&#x0098;&#x009C;&#xC29C;&#xC29B;&#xC298;&#xC288;&#xC289;','')"/>
+ <xsl:value-of select="marc:subfield[@code='a'][1]" />
+<xsl:if test="marc:subfield[@code='e'][1]"><xsl:text> : </xsl:text><xsl:value-of select="marc:subfield[@code='e'][1]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='c'][1]"><xsl:text> . </xsl:text><xsl:value-of select="marc:subfield[@code='c'][1]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='d'][1]"><xsl:text> = </xsl:text><xsl:value-of select="marc:subfield[@code='d'][1]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='h'][1]"><xsl:text> . </xsl:text><xsl:value-of select="marc:subfield[@code='h'][1]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='i'][1]"><xsl:text> . </xsl:text><xsl:value-of select="marc:subfield[@code='i'][1]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='e'][2]"><xsl:text> : </xsl:text><xsl:value-of select="marc:subfield[@code='e'][2]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='c'][2]"><xsl:text> . </xsl:text><xsl:value-of select="marc:subfield[@code='c'][1]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='d'][2]"><xsl:text> = </xsl:text><xsl:value-of select="marc:subfield[@code='d'][2]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='h'][2]"><xsl:text> . </xsl:text><xsl:value-of select="marc:subfield[@code='h'][2]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='i'][2]"><xsl:text> . </xsl:text><xsl:value-of select="marc:subfield[@code='i'][2]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='e'][3]"><xsl:text> : </xsl:text><xsl:value-of select="marc:subfield[@code='e'][3]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='c'][3]"><xsl:text> . </xsl:text><xsl:value-of select="marc:subfield[@code='c'][3]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='d'][3]"><xsl:text> = </xsl:text><xsl:value-of select="marc:subfield[@code='d'][3]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='h'][3]"><xsl:text> . </xsl:text><xsl:value-of select="marc:subfield[@code='h'][3]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='i'][3]"><xsl:text> . </xsl:text><xsl:value-of select="marc:subfield[@code='i'][3]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='a'][2]"><xsl:text>. </xsl:text><xsl:value-of select="marc:subfield[@code='a'][2]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='a'][3]"><xsl:text>. </xsl:text><xsl:value-of select="marc:subfield[@code='a'][3]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='b']"><xsl:text> [</xsl:text><xsl:value-of select="marc:subfield[@code='b']"/><xsl:text>] </xsl:text>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='f']">
+<xsl:text> / </xsl:text>
+<xsl:if test="marc:subfield[@code='f'][1]"><xsl:text></xsl:text><xsl:value-of select="marc:subfield[@code='f'][1]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='f'][2]"><xsl:text> ; </xsl:text><xsl:value-of select="marc:subfield[@code='f'][2]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='f'][3]"><xsl:text> ; </xsl:text><xsl:value-of select="marc:subfield[@code='f'][3]" /></xsl:if>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='g'][1]"><xsl:text> ; </xsl:text><xsl:value-of select="marc:subfield[@code='g'][1]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='g'][2]"><xsl:text> ; </xsl:text><xsl:value-of select="marc:subfield[@code='g'][2]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='g'][3]"><xsl:text> ; </xsl:text><xsl:value-of select="marc:subfield[@code='g'][3]" /></xsl:if>
+</h1>
+</xsl:for-each>
+</xsl:if>
+
+
+<!--&&OPAC-->
+<!--<xsl:if test="$biblionumber">
+<span class="results_summary">
+<a>
+<xsl:attribute name="href">/cgi-bin/koha/opac-detail.pl?biblionumber=<xsl:value-of select="$biblionumber"/></xsl:attribute>
+Voir notice à l’OPAC
+</a>
+</span>
+</xsl:if>-->
+
+<xsl:if test="contains($type_doc,'Périodique')">
+<xsl:choose>
+<xsl:when test="$ppn">
+<xsl:call-template name="tag_462_ppn" />
+</xsl:when>
+<xsl:otherwise>
+<xsl:call-template name="tag_462" />
+</xsl:otherwise>
+</xsl:choose>
+</xsl:if>
+
+<!--Titre de serie autorité 461-->
+<!--
+<xsl:call-template name="tag_461" />
+-->
+
+<!--Titre de serie non autorité 461-->
+<xsl:call-template name="tag_461bis" />
+
+<!--Titre dépouillé 463-->
+<xsl:call-template name="tag_463" />
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">412</xsl:with-param>
+<xsl:with-param name="label">Est un extrait ou tiré à part de</xsl:with-param>
+</xsl:call-template>
+
+<!--413 Extrait ou tiré à part-->
+<xsl:for-each select="marc:datafield[@tag=413]">
+<span class="results_summary">
+<span class="label">A pour extrait ou tiré à part : </span>
+<xsl:choose>
+<xsl:when test="(marc:subfield[@code='t']) and (marc:subfield[@code='o']) and  (marc:subfield[@code='f']) and (marc:subfield[@code='c']) and (marc:subfield[@code='n']) and (marc:subfield[@code='d'])">
+ <xsl:value-of select="marc:subfield[@code='t']"/>
+<xsl:text> : </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='o']"/>
+<xsl:text> / </xsl:text>
+<xsl:value-of select="marc:subfield[@code='f']"/>
+ <xsl:text>. - </xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+ <xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='n']"/>
+ <xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='t']) and (marc:subfield[@code='o']) and (marc:subfield[@code='c']) and (marc:subfield[@code='n']) and (marc:subfield[@code='d'])">
+ <xsl:value-of select="marc:subfield[@code='t']"/>
+<xsl:text> : </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='o']"/>
+ <xsl:text>. - </xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+ <xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='n']"/>
+ <xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='t']) and (marc:subfield[@code='f']) and (marc:subfield[@code='c']) and (marc:subfield[@code='n']) and (marc:subfield[@code='d'])">
+ <xsl:value-of select="marc:subfield[@code='t']"/>
+<xsl:text> / </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='f']"/>
+ <xsl:text>. - </xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+ <xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='n']"/>
+ <xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='t']) and (marc:subfield[@code='c']) and (marc:subfield[@code='n']) and (marc:subfield[@code='d'])">
+ <xsl:value-of select="marc:subfield[@code='t']"/>
+ <xsl:text>. - </xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+ <xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='n']"/>
+ <xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+</xsl:when>
+<xsl:when test="marc:subfield[@code='t']">
+ <xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:when>
+</xsl:choose>
+</span>
+ </xsl:for-each>
+
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">421</xsl:with-param>
+<xsl:with-param name="label">A pour supplément</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">422</xsl:with-param>
+<xsl:with-param name="label">Est un supplément de</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">423</xsl:with-param>
+<xsl:with-param name="label">Est publié avec</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">424</xsl:with-param>
+<xsl:with-param name="label">Est mis à jour par</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">430</xsl:with-param>
+<xsl:with-param name="label">Suite de</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">431</xsl:with-param>
+<xsl:with-param name="label">Succède après scission à</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">432</xsl:with-param>
+<xsl:with-param name="label">Remplace</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">433</xsl:with-param>
+<xsl:with-param name="label">Remplace partiellement</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">434</xsl:with-param>
+<xsl:with-param name="label">Absorbe</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">435</xsl:with-param>
+<xsl:with-param name="label">Absorbe partiellement</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">436</xsl:with-param>
+<xsl:with-param name="label">Fusion de</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">437</xsl:with-param>
+<xsl:with-param name="label">Suite partielle de</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">440</xsl:with-param>
+<xsl:with-param name="label">Devient</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">441</xsl:with-param>
+<xsl:with-param name="label">Devient partiellement</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">442</xsl:with-param>
+<xsl:with-param name="label">Remplacé par</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">443</xsl:with-param>
+<xsl:with-param name="label">Remplacé partiellement par</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">444</xsl:with-param>
+<xsl:with-param name="label">Absorbé par</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">447</xsl:with-param>
+<xsl:with-param name="label">Fusionné avec...pour former</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">451</xsl:with-param>
+<xsl:with-param name="label">A pour autre édition, sur le même support</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">452</xsl:with-param>
+<xsl:with-param name="label">A pour autre édition, sur un support différent</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">453</xsl:with-param>
+<xsl:with-param name="label">Traduit sous le titre</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">454</xsl:with-param>
+<xsl:with-param name="label">Est une traduction de</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">455</xsl:with-param>
+<xsl:with-param name="label">Est une reproduction de</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">456</xsl:with-param>
+<xsl:with-param name="label">Est reproduit comme</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">464</xsl:with-param>
+<xsl:with-param name="label">Composante</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">470</xsl:with-param>
+<xsl:with-param name="label">Document analysé</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">481</xsl:with-param>
+<xsl:with-param name="label">Est aussi relié dans ce volume</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">482</xsl:with-param>
+<xsl:with-param name="label">Relié à la suite de</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">488</xsl:with-param>
+<xsl:with-param name="label">Autre type de relation</xsl:with-param>
+</xsl:call-template>
+
+<xsl:if test="marc:datafield[@tag=099]/marc:subfield[@code='t']">
+  <span class="results_summary">
+    <span class="label">Catégorie de document : </span>
+    <xsl:for-each select="marc:datafield[@tag=099]/marc:subfield[@code='t']">
+      <xsl:value-of select="."/>
+      <xsl:if test="not(position()=last())"><xsl:text> ; </xsl:text></xsl:if>
+    </xsl:for-each>
+  </span>
+</xsl:if>
+
+<xsl:if test="marc:datafield[@tag=099]/marc:subfield[@code='y']">
+<span class="results_summary creator">
+<span class="label">Créateur de la notice : </span>
+<xsl:for-each select="marc:datafield[@tag=099]">
+<xsl:value-of select="marc:subfield[@code='y']"/>
+<xsl:choose>
+<xsl:when test="position()=last()">
+<xsl:text> </xsl:text>
+</xsl:when>
+<xsl:otherwise>
+<xsl:text>; </xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:for-each>
+</span>
+</xsl:if>
+
+<xsl:if test="marc:datafield[@tag=099]/marc:subfield[@code='z']">
+<span class="results_summary modificator">
+<span class="label">Modificateur de la notice : </span>
+<xsl:for-each select="marc:datafield[@tag=099]">
+<xsl:value-of select="marc:subfield[@code='z']"/>
+<xsl:choose>
+<xsl:when test="position()=last()">
+<xsl:text> </xsl:text>
+</xsl:when>
+<xsl:otherwise>
+<xsl:text>; </xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:for-each>
+</span>
+</xsl:if>
+
+<xsl:if test="not(contains($renvoi,'z'))">
+<xsl:call-template name="tag_7xx">
+<xsl:with-param name="tag">700</xsl:with-param>
+<xsl:with-param name="label">Auteur principal</xsl:with-param>
+<xsl:with-param name="spanclass">main_author</xsl:with-param>
+</xsl:call-template>
+</xsl:if>
+
+<xsl:call-template name="tag_71x">
+<xsl:with-param name="tag">710</xsl:with-param>
+<xsl:with-param name="label">Auteur principal collectivité</xsl:with-param>
+<xsl:with-param name="spanclass">corporate_main_author</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_7xx">
+<xsl:with-param name="tag">701</xsl:with-param>
+<xsl:with-param name="label">Co-auteur</xsl:with-param>
+<xsl:with-param name="spanclass">coauthor</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_7xx">
+<xsl:with-param name="tag">702</xsl:with-param>
+<xsl:with-param name="label">Auteur secondaire</xsl:with-param>
+<xsl:with-param name="spanclass">secondary_author</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_71x">
+<xsl:with-param name="tag">711</xsl:with-param>
+<xsl:with-param name="label">Co-auteur collectivité</xsl:with-param>
+<xsl:with-param name="spanclass">corporate_coauthor</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_71x">
+<xsl:with-param name="tag">712</xsl:with-param>
+<xsl:with-param name="label">Auteur secondaire collectivité</xsl:with-param>
+<xsl:with-param name="spanclass">corporate_secondary_author</xsl:with-param>
+</xsl:call-template>
+
+ <xsl:if test="marc:datafield[@tag=101]">
+ <span class="results_summary language">
+ <span class="label">Langue : </span>
+ <xsl:for-each select="marc:datafield[@tag=101]">
+ <xsl:for-each select="marc:subfield">
+ <xsl:choose>
+ <xsl:when test="@code='b'">du texte intermédiaire, </xsl:when>
+ <xsl:when test="@code='c'">de l'oeuvre originale, </xsl:when>
+ <xsl:when test="@code='d'">du résumé, </xsl:when>
+ <xsl:when test="@code='e'">de la table des matières, </xsl:when>
+ <xsl:when test="@code='f'">de la page de titre, </xsl:when>
+ <xsl:when test="@code='g'">du titre propre, </xsl:when>
+ <xsl:when test="@code='h'">du livret ou des paroles, </xsl:when>
+ <xsl:when test="@code='i'">du matériel d'accompagnement, </xsl:when>
+ <xsl:when test="@code='j'">des sous-titres </xsl:when>
+ </xsl:choose>
+ <xsl:value-of select="text()"/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text>.</xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> ; </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+ </xsl:for-each>
+ </span>
+ </xsl:if>
+
+ <xsl:if test="marc:datafield[@tag=102]">
+ <span class="results_summary country">
+ <span class="label">Pays : </span>
+ <xsl:for-each select="marc:datafield[@tag=102]">
+ <xsl:for-each select="marc:subfield">
+ <xsl:value-of select="text()"/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text>.</xsl:text>
+ </xsl:when>
+ <xsl:otherwise><xsl:text>, </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+ </xsl:for-each>
+ </span>
+ </xsl:if>
+
+ <xsl:if test="marc:datafield[@tag=205]">
+ <span class="results_summary edition">
+ <span class="label">Edition : </span>
+ <xsl:for-each select="marc:datafield[@tag=205]">
+ <xsl:for-each select="marc:subfield">
+ <xsl:value-of select="text()"/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text>.</xsl:text>
+ </xsl:when>
+ <xsl:otherwise><xsl:text>, </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+ </xsl:for-each>
+ </span>
+ </xsl:if>
+
+
+<xsl:if test="(marc:datafield[@tag=214] or marc:datafield[@tag=210])">
+<xsl:choose>
+<xsl:when test="(marc:datafield[@tag=214]/marc:subfield[@code='r'])">
+<xsl:call-template name="tag_214_r" />
+</xsl:when>
+<xsl:when test="(marc:datafield[@tag=214]/marc:subfield[@code='s'])">
+<xsl:call-template name="tag_214_s" />
+</xsl:when>
+<xsl:when test="(marc:datafield[@tag=210]/marc:subfield[@code='r'])">
+<xsl:call-template name="tag_210_r" />
+</xsl:when>
+<xsl:when test="(marc:datafield[@tag=210]/marc:subfield[@code='s'])">
+<xsl:call-template name="tag_210_s" />
+</xsl:when>
+<xsl:when test="(marc:datafield[@tag=214] and  marc:datafield[@tag=210])">
+<xsl:call-template name="tag_214" />
+</xsl:when>
+<xsl:when test="(marc:datafield[@tag=214])">
+<xsl:call-template name="tag_214" />
+</xsl:when>
+<xsl:when test="(marc:datafield[@tag=210])">
+<xsl:call-template name="tag_210" />
+</xsl:when>
+</xsl:choose>
+</xsl:if>
+
+ <xsl:call-template name="tag_215" />
+
+ <!--&&0 PPN 009-->
+ <xsl:if test="marc:controlfield[@tag=009]">
+ <span class="results_summary edition">
+ <span class="label">PPN : </span>
+ <a>
+ <xsl:attribute name="href">http://www.sudoc.fr/<xsl:value-of select="$ppn"/></xsl:attribute>
+ <xsl:value-of select="$ppn"/>
+ </a>
+ </span>
+ </xsl:if>
+
+ <!--N de these-->
+ <xsl:if test="marc:controlfield[@tag=029]">
+ <span class="results_summary thesis_number">
+ <span class="label">N. de thèse : </span>
+ <xsl:for-each select="marc:datafield[@tag=029]">
+ <xsl:value-of select="marc:subfield[@code='a']"/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text>.</xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> ; </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+ </span>
+ </xsl:if>
+
+ <!--ISBN-->
+ <xsl:if test="(marc:datafield[@tag=010]/marc:subfield[@code='a']) or (marc:datafield[@tag=010]/marc:subfield[@code='b']) or (marc:datafield[@tag=010]/marc:subfield[@code='z'])">
+ <span class="results_summary isbn">
+ <span class="label">ISBN : </span>
+ <xsl:for-each select="marc:datafield[@tag=010]">
+ <xsl:choose>
+ <xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='b']) and (marc:subfield[@code='z'])">
+ <xsl:value-of select="marc:subfield[@code='a']"/>
+ <xsl:text> ; </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='z']"/><xsl:text> (erroné)</xsl:text>
+ <xsl:text>  </xsl:text>
+ <xsl:text>(</xsl:text><xsl:value-of select="marc:subfield[@code='b']"/><xsl:text>)</xsl:text>
+ </xsl:when>
+ <xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='b'])">
+ <xsl:value-of select="marc:subfield[@code='a']"/>
+ <xsl:text>  </xsl:text>
+ <xsl:text>(</xsl:text><xsl:value-of select="marc:subfield[@code='b']"/><xsl:text>)</xsl:text>
+ </xsl:when>
+ <xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='z'])">
+ <xsl:value-of select="marc:subfield[@code='a']"/>
+ <xsl:text> ; </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='z']"/><xsl:text> (erroné)</xsl:text>
+ </xsl:when>
+ <xsl:when test="(marc:subfield[@code='b']) and (marc:subfield[@code='z'])">
+ <xsl:value-of select="marc:subfield[@code='z']"/>
+ <xsl:text> (erroné) </xsl:text><xsl:text>(</xsl:text>
+ <xsl:value-of select="marc:subfield[@code='b']"/><xsl:text>)</xsl:text>
+ </xsl:when>
+ <xsl:when test="(marc:subfield[@code='a'])">
+ <xsl:value-of select="marc:subfield[@code='a']"/>
+ </xsl:when>
+ <xsl:when test="(marc:subfield[@code='b'])">
+ <xsl:value-of select="marc:subfield[@code='b']"/>
+ </xsl:when>
+ <xsl:when test="(marc:subfield[@code='d'])">
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+ </xsl:when>
+ </xsl:choose>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> .- </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+ </span>
+ </xsl:if>
+
+ <xsl:if test="marc:datafield[@tag=010]/marc:subfield[@code='d']">
+ <span class="results_summary price">
+ <span class="label">Prix : </span>
+ <xsl:for-each select="marc:datafield[@tag=010]">
+ <xsl:variable name="isbn" select="marc:subfield[@code='d']"/>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text>.</xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> ; </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+ </span>
+ </xsl:if>
+
+ <xsl:if test="marc:datafield[@tag=011]">
+ <span class="results_summary publication">
+ <span class="label">ISSN : </span>
+ <xsl:for-each select="marc:datafield[@tag=011]">
+ <xsl:value-of select="marc:subfield[@code='a']"/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text>.</xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text>; </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+ </span>
+ </xsl:if>
+
+ <xsl:call-template name="tag_title_collection">
+ <xsl:with-param name="tag">225</xsl:with-param>
+ <xsl:with-param name="label">Collection</xsl:with-param>
+ <xsl:with-param name="spanclass">series</xsl:with-param>
+ </xsl:call-template>
+
+<!--410 Collection-->
+<xsl:for-each select="marc:datafield[@tag=410]">
+ <span class="results_summary tag_410">
+ <span class="label">Appartient à la collection : </span>
+ <span>
+<xsl:choose>
+<xsl:when test="(marc:subfield[@code='9']) and (marc:subfield[@code='x']) and (marc:subfield[@code='v'])">
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?q=an:<xsl:value-of select="marc:subfield[@code='9']"/></xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:element>
+<xsl:text>, ISSN </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=ns&amp;q=<xsl:value-of select="marc:subfield[@code='x']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x']"/></xsl:element>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='v']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='9'])  and (marc:subfield[@code='v'])">
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?q=an:<xsl:value-of select="marc:subfield[@code='9']"/></xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:element>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='v']"/>
+      </xsl:when>
+<xsl:when test="(marc:subfield[@code='9']) and (marc:subfield[@code='x'])">
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?q=an:<xsl:value-of select="marc:subfield[@code='9']"/></xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:element>
+<xsl:text>, ISSN </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=ns&amp;q=<xsl:value-of select="marc:subfield[@code='x']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x']"/></xsl:element>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='t']) and (marc:subfield[@code='x']) and (marc:subfield[@code='v'])">
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=Title-series&amp;q=<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='t']"/></xsl:element>
+<xsl:text>, ISSN </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=ns&amp;q=<xsl:value-of select="marc:subfield[@code='x']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x']"/></xsl:element>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='v']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='t'])  and (marc:subfield[@code='v'])">
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=Title-series&amp;q=<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='t']"/></xsl:element>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='v']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='t'])">
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=Title-series&amp;q=<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='t']"/></xsl:element>
+</xsl:when>
+ </xsl:choose>
+</span>
+</span>
+</xsl:for-each>
+
+
+<!--500 TITRE UNIFORME-->
+<xsl:for-each select="marc:datafield[@tag=500]">
+ <span class="results_summary uniform_title">
+ <span class="label">Titre Uniforme : </span>
+ <xsl:if test="marc:subfield[@code='a']">
+<xsl:text>[</xsl:text>
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:choose>
+<xsl:when test="(marc:subfield[@code='i']) and (marc:subfield[@code='m']) and  (marc:subfield[@code='k'])">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='i']"/>
+<xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='m']"/>
+<xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='k']"/>
+ <xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='i']) and (marc:subfield[@code='l'])">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='i']"/>
+<xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='l']"/>
+ <xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='m']) and (marc:subfield[@code='k'])">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='m']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='k']"/>
+ <xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='i']) and (marc:subfield[@code='k'])">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='i']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='k']"/>
+ <xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='i'][3])">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='i'][1]"/>
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='i'][2]"/>
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='i'][3]"/>
+ <xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='i'][2])">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='i'][1]"/>
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='i'][2]"/>
+ <xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='l'])">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='l']"/>
+ <xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:otherwise>
+<xsl:text>]</xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:if>
+ </span>
+ </xsl:for-each>
+
+
+<!--503 TITRE FORME-->
+<xsl:for-each select="marc:datafield[@tag=503]">
+ <span class="results_summary uniform_conventional_heading">
+ <span class="label">Titre de forme : </span>
+ <xsl:if test="marc:subfield[@code='a']">
+<xsl:text>[</xsl:text>
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:choose>
+<xsl:when test="(marc:subfield[@code='e']) and (marc:subfield[@code='i']) and  (marc:subfield[@code='m']) and  (marc:subfield[@code='n']) and (marc:subfield[@code='o']) and (marc:subfield[@code='j'])">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='i']"/>
+<xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='m']"/>
+<xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='n']"/>
+<xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='o']"/>
+<xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='j']"/>
+ <xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='e']) and (marc:subfield[@code='m']) and (marc:subfield[@code='n']) and (marc:subfield[@code='o']) and (marc:subfield[@code='j'])">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='m']"/>
+<xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='n']"/>
+<xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='o']"/>
+<xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='j']"/>
+ <xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='m']) and (marc:subfield[@code='n']) and (marc:subfield[@code='o']) and (marc:subfield[@code='j'])">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='m']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='n']"/>
+<xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='o']"/>
+<xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='j']"/>
+ <xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='e']) and (marc:subfield[@code='m']) and (marc:subfield[@code='n']) and (marc:subfield[@code='j'])">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='e']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='m']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='n']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='j']"/>
+<xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='m']) and (marc:subfield[@code='n']) and (marc:subfield[@code='j'])">
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='m']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='n']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='j']"/>
+<xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='b']) and (marc:subfield[@code='j'])">
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='b']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='j']"/>
+<xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='e']) and (marc:subfield[@code='h']) and (marc:subfield[@code='j'])">
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='h']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='j']"/>
+<xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='e']) and (marc:subfield[@code='f']) and (marc:subfield[@code='h'])">
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='f']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='h']"/>
+<xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='e']) and (marc:subfield[@code='f'])">
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='f']"/>
+<xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='i']) and (marc:subfield[@code='n'])">
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='i']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='n']"/>
+<xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='m']) and (marc:subfield[@code='n'])">
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='m']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='n']"/>
+<xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='m']) and (marc:subfield[@code='j'])">
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='m']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='j']"/>
+<xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='m'])">
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='m']"/>
+<xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:otherwise>
+<xsl:text>]</xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:if>
+</span>
+</xsl:for-each>
+
+<!--517 AUTRE TITRE-->
+<xsl:for-each select="marc:datafield[@tag=517]">
+<span class="results_summary other_title">
+<span class="label">Autre(s) titre(s) : </span>
+ <xsl:if test="marc:subfield[@code='a']">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:choose>
+<xsl:when test="(marc:subfield[@code='e']) and (marc:subfield[@code='h']) and  (marc:subfield[@code='i'])">
+ <xsl:text>: </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='h']"/>
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='i']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='e'])">
+ <xsl:text>: </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='e']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='j'])">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='j']"/>
+</xsl:when>
+</xsl:choose>
+</xsl:if>
+</span>
+</xsl:for-each>
+
+ <xsl:if test="marc:datafield[@tag=686]">
+ <span class="results_summary tag_686">
+ <span class="label">Autre classification : </span>
+ <xsl:for-each select="marc:datafield[@tag=686]">
+ <xsl:value-of select="marc:subfield[@code='a']"/>
+ <xsl:if test="marc:subfield[@code='2']">
+ <xsl:text>, </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='2']"/>
+ </xsl:if>
+ <xsl:if test="marc:subfield[@code='z']">
+ <xsl:text>, </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='z']"/>
+ </xsl:if>
+ <xsl:if test="not (position()=last())">
+ <xsl:text> ; </xsl:text>
+ </xsl:if>
+ </xsl:for-each>
+ </span>
+ </xsl:if>
+
+ <xsl:if test="marc:datafield[@tag=675]"> 
+ <span class="results_summary tag_675">
+ <span class="label">Classification-675 : </span>
+ <xsl:for-each select="marc:datafield[@tag=675]">
+ <xsl:value-of select="marc:subfield[@code='a']"/>
+ <xsl:if test="marc:subfield[@code='b']">
+ <xsl:text>, </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='b']"/>
+ </xsl:if>
+ <xsl:if test="marc:subfield[@code='c']">
+ <xsl:text>, </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='c']"/>
+ </xsl:if>
+ <xsl:if test="not (position()=last())"><xsl:text> ; </xsl:text></xsl:if>
+ </xsl:for-each>
+ </span>
+ </xsl:if>
+
+
+ <xsl:if test="marc:datafield[@tag=676]">
+ <span class="results_summary tag_676">
+ <span class="label">Classification-676 : </span>
+ <xsl:for-each select="marc:datafield[@tag=676]">
+ <xsl:value-of select="marc:subfield[@code='a']"/>
+ <xsl:if test="marc:subfield[@code='b']">
+ <xsl:text>, </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='b']"/>
+ </xsl:if>
+ <xsl:if test="marc:subfield[@code='c']">
+ <xsl:text>, </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='c']"/>
+ </xsl:if>
+ <xsl:if test="not (position()=last())"><xsl:text> ; </xsl:text></xsl:if>
+ </xsl:for-each>
+ </span>
+ </xsl:if>
+
+ <!--onglet Description-->
+ <div id="tab-content-descr" class="tab-content">
+ <p>
+ <xsl:if test="marc:datafield[@tag=300]">
+ <dl>
+ <strong>Note générale : </strong>
+ <xsl:for-each select="marc:datafield[@tag=300]">
+ <xsl:for-each select="marc:subfield[@code='a']">
+ <xsl:value-of select="."/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> | </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+ </xsl:for-each>
+ </dl>
+ </xsl:if>
+ </p>
+ <p>
+ <xsl:if test="marc:datafield[@tag=303]">
+ <dl>
+ <strong>Note sur la description bibliographique : </strong>
+ <xsl:for-each select="marc:datafield[@tag=303]">
+ <xsl:for-each select="marc:subfield[@code='a']">
+ <xsl:value-of select="."/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> | </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+ </xsl:for-each>
+ </dl>
+ </xsl:if>
+ </p>
+ <p>
+ <xsl:if test="marc:datafield[@tag=304]">
+ <dl>
+ <strong>Note sur le titre et les responsabilités : </strong>
+ <xsl:for-each select="marc:datafield[@tag=304]">
+ <xsl:for-each select="marc:subfield[@code='a']">
+ <xsl:value-of select="."/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> | </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+ </xsl:for-each>
+ </dl>
+ </xsl:if>
+ </p>
+ <p>
+ <xsl:if test="marc:datafield[@tag=305]">
+ <dl>
+ <strong>Note sur l'édition et l'histoire : </strong>
+ <xsl:for-each select="marc:datafield[@tag=305]">
+ <xsl:for-each select="marc:subfield[@code='a']">
+ <xsl:value-of select="."/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> | </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+ </xsl:for-each>
+ </dl>
+ </xsl:if>
+ </p>
+ <p>
+ <xsl:if test="marc:datafield[@tag=306]">
+ <dl>
+ <strong>Note sur la publication, production : </strong>
+ <xsl:for-each select="marc:datafield[@tag=306]">
+ <xsl:for-each select="marc:subfield[@code='a']">
+ <xsl:value-of select="."/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> | </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+ </xsl:for-each>
+ </dl>
+ </xsl:if>
+ </p>
+ <p>
+ <xsl:if test="marc:datafield[@tag=307]">
+ <dl>
+ <strong>Note sur la description matérielle : </strong>
+ <xsl:for-each select="marc:datafield[@tag=307]">
+ <xsl:for-each select="marc:subfield[@code='a']">
+ <xsl:value-of select="."/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> | </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+ </xsl:for-each>
+ </dl>
+ </xsl:if>
+ </p>
+ <p>
+ <xsl:if test="marc:datafield[@tag=308]">
+ <dl>
+ <strong>Note sur la collection : </strong>
+ <xsl:for-each select="marc:datafield[@tag=308]">
+ <xsl:for-each select="marc:subfield[@code='a']">
+ <xsl:value-of select="."/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> | </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+ </xsl:for-each>
+ </dl>
+ </xsl:if>
+ </p>
+ <p>
+ <xsl:if test="marc:datafield[@tag=310]">
+ <dl>
+ <strong>Note sur la disponiblité : </strong>
+ <xsl:for-each select="marc:datafield[@tag=310]">
+ <xsl:for-each select="marc:subfield[@code='a']">
+ <xsl:value-of select="."/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> | </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+ </xsl:for-each>
+ </dl>
+ </xsl:if>
+ </p>
+ <p>
+ <xsl:if test="marc:datafield[@tag=311]">
+ <dl>
+ <strong>Note sur les zones de liens : </strong>
+ <xsl:for-each select="marc:datafield[@tag=311]">
+ <xsl:for-each select="marc:subfield[@code='a']">
+ <xsl:value-of select="."/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> | </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+ </xsl:for-each>
+ </dl>
+ </xsl:if>
+ </p>
+ <p>
+ <xsl:if test="marc:datafield[@tag=312]">
+ <dl>
+ <strong>Note sur les titres associés : </strong>
+ <xsl:for-each select="marc:datafield[@tag=312]">
+ <xsl:for-each select="marc:subfield[@code='a']">
+ <xsl:value-of select="."/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> | </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+ </xsl:for-each>
+ </dl>
+ </xsl:if>
+ </p>
+ <p>
+ <xsl:if test="marc:datafield[@tag=314]">
+ <dl>
+ <strong>Note sur la responsabilité : </strong>
+ <xsl:for-each select="marc:datafield[@tag=314]">
+ <xsl:for-each select="marc:subfield[@code='a']">
+ <xsl:value-of select="."/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> | </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+ </xsl:for-each>
+ </dl>
+ </xsl:if>
+ </p>
+ <p>
+ <xsl:if test="marc:datafield[@tag=315]">
+ <dl>
+ <strong>Note relative à la ressource : </strong>
+ <xsl:for-each select="marc:datafield[@tag=315]">
+ <xsl:for-each select="marc:subfield[@code='a']">
+ <xsl:value-of select="."/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> | </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+ </xsl:for-each>
+ </dl>
+ </xsl:if>
+ </p>
+ <!--316 Note sur l'exemplaire-->
+ <p>
+ <xsl:for-each select="marc:datafield[@tag=316]">
+ <dl>
+ <strong>Note sur l'exemplaire : </strong>
+ <xsl:if test="(marc:subfield[@code='a'])">
+ <xsl:value-of select="marc:subfield[@code='a']"/>
+ <xsl:text>. </xsl:text>
+ </xsl:if>
+ <xsl:if test="(marc:subfield[@code='5'])">
+ <xsl:value-of select="marc:subfield[@code='5']"/>
+ <xsl:text>. </xsl:text>
+ </xsl:if>
+ </dl>
+ </xsl:for-each>
+ </p>
+ <!--317 Note sur la provenance-->
+ <p>
+ <xsl:for-each select="marc:datafield[@tag=317]">
+ <dl>
+ <strong>Note sur la provenance : </strong>
+ <xsl:if test="(marc:subfield[@code='a'])">
+ <xsl:value-of select="marc:subfield[@code='a']"/>
+ <xsl:text>. </xsl:text>
+ </xsl:if>
+ <xsl:if test="(marc:subfield[@code='5'])">
+ <xsl:value-of select="marc:subfield[@code='5']"/>
+ <xsl:text>. </xsl:text>
+ </xsl:if>
+ </dl>
+ </xsl:for-each>
+ </p>
+ <p>
+ <xsl:for-each select="marc:datafield[@tag=320]">
+ <dl>
+ <strong>Note sur les bibliographies et les index : </strong>
+ <xsl:if test="(marc:subfield[@code='a'])">
+ <xsl:value-of select="marc:subfield[@code='a']"/>
+ <xsl:text>. </xsl:text>
+ </xsl:if>
+ <xsl:if test="(marc:subfield[@code='u'])">
+ <xsl:value-of select="marc:subfield[@code='u']"/>
+ <xsl:text>. </xsl:text>
+ </xsl:if>
+ </dl>
+ </xsl:for-each>
+ </p>
+ <p>
+ <xsl:for-each select="marc:datafield[@tag=321]">
+ <dl>
+ <strong>Note sur les  index, extrait, citations publiés séparément : </strong>
+ <xsl:if test="(marc:subfield[@code='a'])">
+ <xsl:value-of select="marc:subfield[@code='a']"/>
+ <xsl:text>. </xsl:text>
+ </xsl:if>
+ <xsl:if test="(marc:subfield[@code='u'])">
+ <xsl:value-of select="marc:subfield[@code='u']"/>
+ <xsl:text>. </xsl:text>
+ </xsl:if>
+ </dl>
+ </xsl:for-each>
+ </p>
+ <p>
+ <xsl:for-each select="marc:datafield[@tag=322]">
+ <dl>
+ <strong>Note sur le générique : </strong>
+ <xsl:if test="(marc:subfield[@code='a'])">
+ <xsl:value-of select="marc:subfield[@code='a']"/>
+ <xsl:text>. </xsl:text>
+ </xsl:if>
+ <xsl:if test="(marc:subfield[@code='u'])">
+ <xsl:value-of select="marc:subfield[@code='u']"/>
+ <xsl:text>. </xsl:text>
+ </xsl:if>
+ </dl>
+ </xsl:for-each>
+ </p>
+ <p>
+ <xsl:for-each select="marc:datafield[@tag=323]">
+ <dl>
+ <strong>Note sur les interprètes : </strong>
+ <xsl:if test="(marc:subfield[@code='a'])">
+ <xsl:value-of select="marc:subfield[@code='a']"/>
+ <xsl:text>. </xsl:text>
+ </xsl:if>
+ <xsl:if test="(marc:subfield[@code='u'])">
+ <xsl:value-of select="marc:subfield[@code='u']"/>
+ <xsl:text>. </xsl:text>
+ </xsl:if>
+ </dl>
+ </xsl:for-each>
+ </p>
+ <p>
+ <xsl:for-each select="marc:datafield[@tag=324]">
+ <dl>
+ <strong>Note sur l’original reproduit : </strong>
+ <xsl:if test="(marc:subfield[@code='a'])">
+ <xsl:value-of select="marc:subfield[@code='a']"/>
+ <xsl:text>. </xsl:text>
+ </xsl:if>
+ <xsl:if test="(marc:subfield[@code='u'])">
+ <xsl:value-of select="marc:subfield[@code='u']"/>
+ <xsl:text>. </xsl:text>
+ </xsl:if>
+ </dl>
+ </xsl:for-each>
+ </p>
+ <p>
+ <xsl:if test="marc:datafield[@tag=325]">
+ <dl>
+ <strong>Note sur la reproduction : </strong>
+ <xsl:for-each select="marc:datafield[@tag=325]">
+ <xsl:for-each select="marc:subfield[@code='a']">
+ <xsl:value-of select="."/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> | </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+ </xsl:for-each>
+ </dl>
+ </xsl:if>
+ </p>
+ <p>
+ <xsl:if test="marc:datafield[@tag=327]">
+ <dl>
+ <strong>Note de contenu : </strong>
+ <xsl:for-each select="marc:datafield[@tag=327]">
+ <xsl:for-each select="marc:subfield[@code='a']">
+ <xsl:value-of select="."/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> | </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+ </xsl:for-each>
+ </dl>
+ </xsl:if>
+ </p>
+ <p>
+ <xsl:if test="marc:datafield[@tag=326]">
+ <dl>
+ <strong>Périodicité : </strong>
+ <xsl:for-each select="marc:datafield[@tag=326]">
+ <xsl:value-of select="marc:subfield[@code='a']"/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text>; </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+ </dl>
+ </xsl:if>
+ </p>
+ <p>
+ <xsl:if test="marc:datafield[@tag=328]">
+ <dl>
+ <strong>Note de thèse : </strong>
+ <xsl:for-each select="marc:datafield[@tag=328]">
+ <xsl:for-each select="marc:subfield">
+ <xsl:value-of select="text()"/>
+ <xsl:choose><xsl:when test="position()=last()"><xsl:text> . </xsl:text></xsl:when><xsl:otherwise><xsl:text> - </xsl:text></xsl:otherwise></xsl:choose>
+ </xsl:for-each>
+ </xsl:for-each>
+ </dl>
+ </xsl:if>
+ </p>
+ <p>
+ <xsl:if test="marc:datafield[@tag=333]">
+ <dl>
+ <strong>Note sur le plublic destinataire : </strong>
+ <xsl:for-each select="marc:datafield[@tag=336]">
+ <xsl:for-each select="marc:subfield">
+ <xsl:value-of select="text()"/>
+ <xsl:choose><xsl:when test="position()=last()"><xsl:text> . </xsl:text></xsl:when><xsl:otherwise><xsl:text> - </xsl:text></xsl:otherwise></xsl:choose>
+ </xsl:for-each>
+ </xsl:for-each>
+ </dl>
+ </xsl:if>
+ </p>
+ <p>
+ <xsl:if test="marc:datafield[@tag=334]">
+ <dl>
+ <strong>Note sur la récompense : </strong>
+ <xsl:for-each select="marc:datafield[@tag=336]">
+ <xsl:for-each select="marc:subfield">
+ <xsl:value-of select="text()"/>
+ <xsl:choose><xsl:when test="position()=last()"><xsl:text> . </xsl:text></xsl:when><xsl:otherwise><xsl:text> - </xsl:text></xsl:otherwise></xsl:choose>
+ </xsl:for-each>
+ </xsl:for-each>
+ </dl>
+ </xsl:if>
+ </p>
+ <p>
+ <xsl:if test="marc:datafield[@tag=336]">
+ <dl>
+ <strong>Type de ressources électronique : </strong>
+ <xsl:for-each select="marc:datafield[@tag=336]">
+ <xsl:for-each select="marc:subfield">
+ <xsl:value-of select="text()"/>
+ <xsl:choose><xsl:when test="position()=last()"><xsl:text> . </xsl:text></xsl:when><xsl:otherwise><xsl:text> - </xsl:text></xsl:otherwise></xsl:choose>
+ </xsl:for-each>
+ </xsl:for-each>
+ </dl>
+ </xsl:if>
+ </p>
+ <p>
+ <xsl:if test="marc:datafield[@tag=337]">
+ <dl>
+ <strong>Note de thèses et écrits académiques : </strong>
+ <xsl:for-each select="marc:datafield[@tag=337]">
+ <xsl:for-each select="marc:subfield">
+ <xsl:value-of select="text()"/>
+ <xsl:choose><xsl:when test="position()=last()"><xsl:text> . </xsl:text></xsl:when><xsl:otherwise><xsl:text> - </xsl:text></xsl:otherwise></xsl:choose>
+ </xsl:for-each>
+ </xsl:for-each>
+ </dl>
+ </xsl:if>
+ </p>
+ <xsl:if test="marc:datafield[@tag=330]">
+ <dl>
+ <strong>Résumé : </strong>
+ <xsl:for-each select="marc:datafield[@tag=330]">
+ <xsl:value-of select="marc:subfield[@code='a']"/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <br></br><xsl:text> </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+ </dl>
+ </xsl:if>
+
+<xsl:if test="marc:datafield[@tag=359]">
+<strong>Table des matières : </strong>
+<xsl:for-each select="marc:datafield[@tag=359]">
+<xsl:for-each select="marc:subfield">
+<xsl:choose>
+ <xsl:when test="@code='b'"><dt><xsl:value-of select="text()"/></dt></xsl:when>
+ <xsl:when test="@code='c'"><dd><xsl:value-of select="text()"/></dd></xsl:when>
+ <xsl:when test="@code='d'"><ul><dd><xsl:value-of select="text()"/></dd></ul></xsl:when>
+ <xsl:when test="@code='e'"><ul><ul><dd><xsl:value-of select="text()"/></dd></ul></ul></xsl:when>
+ <xsl:when test="@code='f'"><ul><ul><dd> <xsl:value-of select="text()"/></dd></ul></ul></xsl:when>
+ <xsl:when test="@code='g'"><ul><ul><dd><xsl:value-of select="text()"/></dd></ul></ul></xsl:when>
+ <xsl:when test="@code='h'"><ul><ul><dd><xsl:value-of select="text()"/></dd></ul></ul></xsl:when>
+ <xsl:when test="@code='i'"><ul><ul><dd><xsl:value-of select="text()"/></dd></ul></ul></xsl:when>
+</xsl:choose>
+</xsl:for-each>
+</xsl:for-each>
+</xsl:if>
+</div>
+
+
+<!--&&8 sons clips 464u-->
+<!--<xsl:if test="marc:datafield[@tag=464]"> 
+   <div class="panel panel-default results_summary"> 
+     <div class="panel-heading" style="background-color:#FAFAFA"> 
+     Contenu : 
+     </div> 
+    <div class="panel-body" style="height:190px;overflow:auto;background-color:#FAFAFA"> 
+
+      <xsl:for-each select="marc:datafield[@tag=464]"> 
+    <p> 
+        <xsl:choose> 
+        <xsl:when test="marc:subfield[@code='u']"> 
+        <a> 
+        <xsl:attribute name="href"><xsl:value-of select="marc:subfield[@code='u']"/></xsl:attribute> 
+        <xsl:attribute name="title"><xsl:text>play-pause</xsl:text></xsl:attribute> 
+        <xsl:attribute name="class"><xsl:text>sm2_button</xsl:text></xsl:attribute>  
+        <img id="play" width="18" height="18"><xsl:attribute name="src">/public/images/play.png</xsl:attribute></img> 
+        </a> 
+        </xsl:when> 
+        <xsl:otherwise> 
+          <img id="noplay" width="18" height="18"><xsl:attribute name="src">/public/images/noplay.png</xsl:attribute></img> 
+        </xsl:otherwise> 
+        </xsl:choose> 
+        <xsl:text> - </xsl:text> 
+       <xsl:if test="marc:subfield[@code='t']"> 
+        <xsl:value-of select="marc:subfield[@code='t']"/><xsl:text> - </xsl:text> 
+        </xsl:if> 
+        <xsl:choose> 
+        <xsl:when test="marc:subfield[@code='t']"><xsl:value-of select="marc:subfield[@code='t']"/></xsl:when> 
+        <xsl:when test="marc:subfield[@code='h']"><xsl:value-of select="marc:subfield[@code='h']"/></xsl:when> 
+        <xsl:otherwise>Titre inconnu</xsl:otherwise> 
+        </xsl:choose> 
+        <xsl:if test="marc:subfield[@code='a']"> 
+           <i> 
+<xsl:for-each select="marc:subfield[@code='a']"> 
+           <xsl:text> - </xsl:text><xsl:value-of select="."/> 
+           </xsl:for-each> 
+           </i> 
+        </xsl:if> 
+    </p> 
+      </xsl:for-each> 
+      </div> 
+      </div> 
+  </xsl:if>-->
+
+
+
+<!--&&13 Descripteur 610-->
+<xsl:if test="marc:datafield[@tag=610]">
+<span class="results_summary tag_610">
+<span class="label">Descripteur : </span>
+<xsl:for-each select="marc:datafield[@tag=610]">
+<xsl:choose>
+<xsl:when test="contains(marc:subfield[@code='a'],'(')">
+<a>
+<xsl:attribute name="href">/cgi-bin/koha/catalogue/search.pl?q=su,phr:
+<xsl:value-of select="substring-before(marc:subfield[@code='a'], '(')" />
+<xsl:value-of select="substring-before(substring-after(marc:subfield[@code='a'], '('), ')')" />
+<xsl:value-of select="substring-after(marc:subfield[@code='a'], ')')" />
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='a']"/>
+</a>
+</xsl:when>
+<xsl:otherwise>
+<a>
+<xsl:attribute name="href">/cgi-bin/koha/catalogue/search.pl?q=su,phr:<xsl:value-of select="marc:subfield[@code='a']"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='a']"/>
+</a>
+ </xsl:otherwise>
+</xsl:choose>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> .  </xsl:text>
+</xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+ </span>
+</xsl:if>
+
+
+<!--&&15 cover cd dvd-->
+<!--<xsl:if test="$coverCD!=' '">
+<div id='jacquette'>
+      <xsl:if test="marc:datafield[@tag=933]">
+      <xsl:for-each select="marc:datafield[@tag=933]">
+        <img class="coverimages" height="80" width="80"><xsl:attribute name="src"><xsl:value-of select="marc:subfield[@code='a']"/></xsl:attribute></img>
+          <xsl:choose>
+            <xsl:when test="position()=last()"/>
+          </xsl:choose>
+        </xsl:for-each>
+      </xsl:if> </div></xsl:if>-->
+
+
+
+
+<!--&& Etat de collection - SUDOC-->
+<xsl:if test="marc:datafield[@tag=923]">
+    <dt class="prolabelxslt">État des collections</dt>
+         <xsl:for-each select="marc:datafield[@tag=923]">
+ <xsl:if test="marc:subfield[@code='r']">
+            <xsl:if test="marc:subfield[@code='b']">
+              <dd>
+              <xsl:if test="marc:subfield[@code='b']">
+                        <xsl:call-template name="RCR">
+                            <xsl:with-param name="code" select="marc:subfield[@code='b']"/>
+                        </xsl:call-template>
+                  </xsl:if>
+                      <xsl:if test="marc:subfield[@code='r']">
+                  <xsl:text> : </xsl:text>
+                  <span class="statutdispo">
+                                <xsl:value-of select="marc:subfield[@code='r']"/>
+                  </span>
+                      </xsl:if>
+              </dd>
+            </xsl:if>
+            <xsl:if test="marc:subfield[@code='W']">
+              <dd>
+                <span class="profctxslt">
+                  <xsl:text>Lacunes : </xsl:text>
+                  <xsl:value-of select="marc:subfield[@code='W']"/>
+                </span>
+              </dd>
+            </xsl:if>
+                        <xsl:if test="marc:subfield[@code='Z']">
+              <dd>
+                <span class="profctxslt">
+                  <xsl:text>Notes : </xsl:text>
+                  <xsl:value-of select="marc:subfield[@code='Z']"/>
+                </span>
+              </dd>
+            </xsl:if>
+<xsl:if test="marc:subfield[@code='a'] or marc:subfield[@code='c'] or marc:subfield[@code='d']">
+              <dd>
+                <span class="profctxslt">
+                <xsl:if test="marc:subfield[@code='a']">
+                  <xsl:text>Cote : </xsl:text>
+                  <xsl:value-of select="marc:subfield[@code='a']" />
+                </xsl:if>
+                <xsl:if test="marc:subfield[@code='c']">
+                    <xsl:choose>
+                      <xsl:when test="marc:subfield[@code='a']">
+                        <xsl:text> ; Localisation : </xsl:text>
+                      </xsl:when>
+                      <xsl:otherwise>
+                        <xsl:text>Localisation : </xsl:text>
+                      </xsl:otherwise>
+                    </xsl:choose>
+                  <xsl:value-of select="marc:subfield[@code='c']" />
+                </xsl:if>
+                <xsl:if test="marc:subfield[@code='d']">
+                    <xsl:choose>
+                      <xsl:when test="marc:subfield[@code='a'] or marc:subfield[@code='d']">
+                        <xsl:text> ; </xsl:text>
+                      </xsl:when>
+                      <xsl:otherwise>
+                      </xsl:otherwise>
+                    </xsl:choose>
+                  <xsl:value-of select="marc:subfield[@code='d']" />
+                </xsl:if>
+              </span>
+              </dd>
+            </xsl:if>
+ </xsl:if>
+         </xsl:for-each>
+                  <xsl:for-each select="marc:datafield[@tag=930]">
+                        <xsl:if test="marc:subfield[@code='z'] or marc:subfield[@code='p']">
+                        <dd>
+                       <!--<span class="profctxslt">-->
+                        <span class="profctxslt">
+                                <xsl:text>Conservation : </xsl:text>
+                                        <xsl:value-of select="marc:subfield[@code='z']" />
+                                        <xsl:text> (</xsl:text>
+                                        <xsl:value-of select="marc:subfield[@code='p']" />
+                                        <xsl:text>)</xsl:text>
+                        </span>
+                        </dd>
+                        </xsl:if>
+                  </xsl:for-each>
+</xsl:if>
+
+<xsl:if test="marc:datafield[@tag=924]">
+    <dt class="prolabelxslt">État des lacunes</dt>
+         <xsl:for-each select="marc:datafield[@tag=924]">
+ <xsl:if test="marc:subfield[@code='r']">
+            <xsl:if test="marc:subfield[@code='b']">
+              <dd>
+              <xsl:if test="marc:subfield[@code='b']">
+                        <xsl:call-template name="RCR">
+                            <xsl:with-param name="code" select="marc:subfield[@code='b']"/>
+                        </xsl:call-template>
+                  </xsl:if>
+                      <xsl:if test="marc:subfield[@code='r']">
+                  <xsl:text> : </xsl:text>
+                  <span class="statutdispo">
+                                <xsl:value-of select="marc:subfield[@code='r']"/>
+                  </span>
+                      </xsl:if>
+              </dd>
+            </xsl:if>
+            <xsl:if test="marc:subfield[@code='W']">
+              <dd>
+                <span class="profctxslt">
+                  <xsl:text>Lacunes : </xsl:text>
+                  <xsl:value-of select="marc:subfield[@code='W']"/>
+                </span>
+              </dd>
+            </xsl:if>
+                        <xsl:if test="marc:subfield[@code='Z']">
+              <dd>
+                <span class="profctxslt">
+                  <xsl:text>Notes : </xsl:text>
+                  <xsl:value-of select="marc:subfield[@code='Z']"/>
+                </span>
+              </dd>
+            </xsl:if>
+<xsl:if test="marc:subfield[@code='a'] or marc:subfield[@code='c'] or marc:subfield[@code='d']">
+              <dd>
+                <span class="profctxslt">
+                <xsl:if test="marc:subfield[@code='a']">
+                  <xsl:text>Cote : </xsl:text>
+                  <xsl:value-of select="marc:subfield[@code='a']" />
+                </xsl:if>
+                <xsl:if test="marc:subfield[@code='c']">
+                    <xsl:choose>
+                      <xsl:when test="marc:subfield[@code='a']">
+                        <xsl:text> ; Localisation : </xsl:text>
+                      </xsl:when>
+                      <xsl:otherwise>
+                        <xsl:text>Localisation : </xsl:text>
+                      </xsl:otherwise>
+                    </xsl:choose>
+                  <xsl:value-of select="marc:subfield[@code='c']" />
+                </xsl:if>
+                <xsl:if test="marc:subfield[@code='d']">
+                    <xsl:choose>
+                      <xsl:when test="marc:subfield[@code='a'] or marc:subfield[@code='d']">
+                        <xsl:text> ; </xsl:text>
+                      </xsl:when>
+
+
+                      <xsl:otherwise>
+                      </xsl:otherwise>
+                    </xsl:choose>
+                  <xsl:value-of select="marc:subfield[@code='d']" />
+                </xsl:if>
+              </span>
+              </dd>
+            </xsl:if>
+ </xsl:if>
+         </xsl:for-each>
+                  <xsl:for-each select="marc:datafield[@tag=930]">
+                        <xsl:if test="marc:subfield[@code='z'] or marc:subfield[@code='p']">
+                        <dd>
+                       <!--<span class="profctxslt">-->
+                        <span class="profctxslt">
+                                <xsl:text>Conservation : </xsl:text>
+                                        <xsl:value-of select="marc:subfield[@code='z']" />
+                                        <xsl:text> (</xsl:text>
+                                        <xsl:value-of select="marc:subfield[@code='p']" />
+                                        <xsl:text>)</xsl:text>
+                        </span>
+                        </dd>
+                        </xsl:if>
+                  </xsl:for-each>
+</xsl:if>
+
+
+
+
+
+
+
+
+<!--&&9 Subject - Name 600-->
+<xsl:for-each select="marc:datafield[@tag=600]">
+<span class="results_summary subjects subject_np">
+<span class="label">Sujet - Nom de personne : </span>
+ <span>
+<xsl:if test="marc:subfield[@code='a']">
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text>+</xsl:text><xsl:if test="marc:subfield[@code='b']!=''"><xsl:value-of select="marc:subfield[@code='b']"/></xsl:if>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='a']"/></xsl:element>
+       </xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='b']">
+<xsl:text>, </xsl:text>
+            <xsl:value-of select="marc:subfield[@code='b']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='d']">
+<xsl:text>, </xsl:text>
+            <xsl:value-of select="marc:subfield[@code='d']"/>
+       </xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='c']">
+<xsl:text>, </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='c']"/></xsl:element>
+       </xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='f']">
+<xsl:text> (</xsl:text>
+           <xsl:value-of select="marc:subfield[@code='f']"/>
+<xsl:text>) </xsl:text>       </xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='x']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='x'][2]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][2]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='x'][3]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][3]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][3]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='y']">
+<xsl:text> -- </xsl:text>
+           <xsl:value-of select="marc:subfield[@code='y']"/>
+       </xsl:if>
+<xsl:if test="marc:subfield[@code='z']">
+<xsl:text> -- </xsl:text>
+           <xsl:value-of select="marc:subfield[@code='z']"/>
+       </xsl:if>
+<xsl:if test="marc:subfield[@code='2']">
+<xsl:text> -- </xsl:text>
+           <xsl:value-of select="marc:subfield[@code='2']"/>
+       </xsl:if>
+<xsl:text> | </xsl:text>
+<!-- recherche sur tous les mots-->
+<xsl:element name="a">
+<xsl:attribute name="href">
+<xsl:text>/cgi-bin/koha/catalogue/search.pl?idx=su&amp;q=</xsl:text>
+<xsl:choose>
+        <xsl:when test="contains(marc:subfield[@code='a'],'(')">
+          <xsl:value-of select="substring-before(marc:subfield[@code='a'], '(')" />
+          <xsl:value-of select="substring-before(substring-after(marc:subfield[@code='a'], '('), ')')" />
+          <xsl:value-of select="substring-after(marc:subfield[@code='a'], ')')" />
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="marc:subfield[@code='a']" />
+        </xsl:otherwise>
+      </xsl:choose>
+<xsl:if test="marc:subfield[@code='b'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='b']!=''"><xsl:value-of select="marc:subfield[@code='b']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='c'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='c']!=''"><xsl:value-of select="marc:subfield[@code='c']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='d'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='d']!=''"><xsl:value-of select="marc:subfield[@code='d']"/></xsl:if><xsl:if test="marc:subfield[@code='x'][1] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][1]!=''"><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][2] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][2]!=''"><xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][3] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][3]!=''"><xsl:value-of select="marc:subfield[@code='x'][3]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='z'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='z']!=''"><xsl:value-of select="marc:subfield[@code='z']"/></xsl:if>
+ </xsl:attribute>
+ <xsl:attribute name="title">Lancer une recherche sur les mots sujet</xsl:attribute>
+ <i class="fa fa-search"></i>
+</xsl:element>
+</span>
+ </span>
+ </xsl:for-each>
+
+
+<!--&&10 Subject collectivity 601-->
+<xsl:for-each select="marc:datafield[@tag=601]">
+<span class="results_summary subjects subject_coll">
+<span class="label">Sujet - Collectivité : </span>
+ <span>
+<xsl:if test="marc:subfield[@code='a']">
+            <xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='a']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='a']"/></xsl:element>
+       </xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='b']">
+<xsl:text>. </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='b'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='b'][1]"/></xsl:element>
+<xsl:if test="marc:subfield[@code='b'][2]">
+<xsl:text>. </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='b'][2]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='b'][2]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='b'][3]">
+<xsl:text>. </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='b'][3]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='b'][3]"/></xsl:element>
+</xsl:if>
+ </xsl:if>
+<xsl:if test="marc:subfield[@code='c']">
+<xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+ </xsl:if>
+<xsl:choose>
+<xsl:when test="(marc:subfield[@code='d']) and (marc:subfield[@code='f']) and (marc:subfield[@code='e'])">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:text> ; </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='f']"/>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='d']) and (marc:subfield[@code='f'])">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:text> ; </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='f']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='d']) and (marc:subfield[@code='e'])">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:text> ; </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='e']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='f']) and (marc:subfield[@code='e'])">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='f']"/>
+<xsl:text> ; </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='e']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+<xsl:when test="marc:subfield[@code='d']">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+</xsl:choose>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='x']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:element>
+<xsl:if test="marc:subfield[@code='x'][2]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][2]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='x'][3]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][3]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][3]"/></xsl:element>           
+</xsl:if>
+       </xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='y']">
+<xsl:text> -- </xsl:text>
+ <xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='y']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='y']"/></xsl:element>
+       </xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='z']">
+<xsl:text> -- </xsl:text>
+            <xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='z']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='z']"/></xsl:element>
+       </xsl:if>
+<xsl:if test="marc:subfield[@code='2']">
+<xsl:text> -- </xsl:text>
+           <xsl:value-of select="marc:subfield[@code='2']"/>
+       </xsl:if>
+<xsl:text> | </xsl:text>
+<!-- recherche sur tous les mots -->
+<xsl:element name="a">
+<xsl:attribute name="href">
+<xsl:text>/cgi-bin/koha/catalogue/search.pl?idx=su&amp;q=</xsl:text>
+<xsl:choose>
+        <xsl:when test="contains(marc:subfield[@code='a'],'(')">
+          <xsl:value-of select="substring-before(marc:subfield[@code='a'], '(')" />
+          <xsl:value-of select="substring-before(substring-after(marc:subfield[@code='a'], '('), ')')" />
+          <xsl:value-of select="substring-after(marc:subfield[@code='a'], ')')" />
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="marc:subfield[@code='a']" />
+        </xsl:otherwise>
+      </xsl:choose> 
+<xsl:if test="marc:subfield[@code='b'][1]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='b'][1]!=''"><xsl:value-of select="marc:subfield[@code='b'][1]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='b'][2]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='b'][2]!=''"><xsl:value-of select="marc:subfield[@code='b'][2]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='b'][3]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='b'][3]!=''"><xsl:value-of select="marc:subfield[@code='b'][3]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][1]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][1]!=''"><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][2]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][2]!=''"><xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][3]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][3]!=''"><xsl:value-of select="marc:subfield[@code='x'][3]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='y'][1] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='y'][1] !=''"><xsl:value-of select="marc:subfield[@code='y'][1]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='y'][2] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='y'][2] !=''"><xsl:value-of select="marc:subfield[@code='y'][2]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='y'][3] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='y'][3] !=''"><xsl:value-of select="marc:subfield[@code='y'][3]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='y'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='y']!=''"><xsl:value-of select="marc:subfield[@code='y']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='z'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='z']!=''"><xsl:value-of select="marc:subfield[@code='z']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='j'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='j']!=''"><xsl:value-of select="marc:subfield[@code='j']"/></xsl:if>
+</xsl:attribute>
+<xsl:attribute name="title">Lancer une recherche sur tous les mots sujet</xsl:attribute>
+<i class="fa fa-search"></i>
+</xsl:element>
+</span>
+ </span>
+ </xsl:for-each>
+
+<xsl:for-each select="marc:datafield[@tag=602]">
+<span class="results_summary subjects subject_fam">
+<span class="label">Sujet - Nom de famille : </span>
+<span>
+<xsl:if test="marc:subfield[@code='a']">
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='a']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='a']"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='b']">
+<xsl:text>. </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='b'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='b'][1]"/></xsl:element>
+<xsl:if test="marc:subfield[@code='b'][2]">
+<xsl:text>. </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='b'][2]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='b'][2]"/></xsl:element>
+</xsl:if>
+
+<xsl:if test="marc:subfield[@code='b'][3]">
+<xsl:text>. </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='b'][3]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='b'][3]"/></xsl:element>
+</xsl:if>
+       </xsl:if>
+<xsl:if test="marc:subfield[@code='c']">
+<xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+ </xsl:if>
+<xsl:choose>
+<xsl:when test="(marc:subfield[@code='d']) and (marc:subfield[@code='f']) and (marc:subfield[@code='e'])">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:text> ; </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='f']"/>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='d']) and (marc:subfield[@code='f'])">
+ <xsl:text> ( </xsl:text>
+</xsl:when>
+<xsl:when test="marc:subfield[@code='d']">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+</xsl:choose>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='t']">
+<xsl:text> -- </xsl:text>
+<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='x']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:element>
+<xsl:if test="marc:subfield[@code='x'][2]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][2]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='x'][3]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][3]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][3]"/></xsl:element></xsl:if>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='y']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='y']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='y']"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='z']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='z']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='z']"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='2']">
+<xsl:text> -- </xsl:text>
+           <xsl:value-of select="marc:subfield[@code='2']"/>
+       </xsl:if>
+<xsl:text> | </xsl:text>
+<!-- recherche sur tous les mots -->
+<xsl:element name="a">
+<xsl:attribute name="href">
+<xsl:text>/cgi-bin/koha/catalogue/search.pl?idx=su&amp;q=</xsl:text>
+<xsl:choose>
+        <xsl:when test="contains(marc:subfield[@code='a'],'(')">
+          <xsl:value-of select="substring-before(marc:subfield[@code='a'], '(')" />
+          <xsl:value-of select="substring-before(substring-after(marc:subfield[@code='a'], '('), ')')" />
+          <xsl:value-of select="substring-after(marc:subfield[@code='a'], ')')" />
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="marc:subfield[@code='a']" />
+        </xsl:otherwise>
+      </xsl:choose> 
+<xsl:if test="marc:subfield[@code='b'][1]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='b'][1]!=''"><xsl:value-of select="marc:subfield[@code='b'][1]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='b'][2]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='b'][2]!=''"><xsl:value-of select="marc:subfield[@code='b'][2]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='b'][3]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='b'][3]!=''"><xsl:value-of select="marc:subfield[@code='b'][3]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][1]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][1]!=''"><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][2]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][2]!=''"><xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][3]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][3]!=''"><xsl:value-of select="marc:subfield[@code='x'][3]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='t']!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='t']!=''"><xsl:value-of select="marc:subfield[@code='t']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='y'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='y']!=''"><xsl:value-of select="marc:subfield[@code='y']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='z'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='z']!=''"><xsl:value-of select="marc:subfield[@code='z']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='j'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='j']!=''"><xsl:value-of select="marc:subfield[@code='j']"/></xsl:if>
+</xsl:attribute>
+<xsl:attribute name="title">Lancer une recherche sur tous les mots sujet</xsl:attribute>
+<i class="fa fa-search"></i>
+</xsl:element>
+</span>
+</span>
+</xsl:for-each>
+
+
+<xsl:for-each select="marc:datafield[@tag=604]">
+<span class="results_summary subjects subject_sauttit">
+<span class="label">Sujet - Auteur/Titre : </span>
+<span>
+<xsl:if test="marc:subfield[@code='a']">
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='a']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='a']"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='b']">
+<xsl:text>. </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='b'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='b'][1]"/></xsl:element>
+<xsl:if test="marc:subfield[@code='b'][2]">
+<xsl:text>. </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='b'][2]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='b'][2]"/></xsl:element>
+</xsl:if>
+
+<xsl:if test="marc:subfield[@code='b'][3]">
+<xsl:text>. </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='b'][3]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='b'][3]"/></xsl:element>
+</xsl:if>
+       </xsl:if>
+<xsl:if test="marc:subfield[@code='c']">
+<xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+ </xsl:if>
+<xsl:choose>
+<xsl:when test="(marc:subfield[@code='d']) and (marc:subfield[@code='f']) and (marc:subfield[@code='e'])">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:text> ; </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='f']"/>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='d']) and (marc:subfield[@code='f'])">
+ <xsl:text> ( </xsl:text>
+</xsl:when>
+<xsl:when test="marc:subfield[@code='d']">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+</xsl:choose>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='t']">
+<xsl:text> -- </xsl:text>
+<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='x']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:element>
+<xsl:if test="marc:subfield[@code='x'][2]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][2]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='x'][3]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][3]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][3]"/></xsl:element></xsl:if>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='y']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='y']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='y']"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='z']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='z']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='z']"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='2']">
+<xsl:text> -- </xsl:text>
+           <xsl:value-of select="marc:subfield[@code='2']"/>
+       </xsl:if>
+<xsl:text> | </xsl:text>
+<!-- recherche sur tous les mots -->
+<xsl:element name="a">
+<xsl:attribute name="href">
+<xsl:text>/cgi-bin/koha/catalogue/search.pl?idx=su&amp;q=</xsl:text>
+<xsl:choose>
+        <xsl:when test="contains(marc:subfield[@code='a'],'(')">
+          <xsl:value-of select="substring-before(marc:subfield[@code='a'], '(')" />
+          <xsl:value-of select="substring-before(substring-after(marc:subfield[@code='a'], '('), ')')" />
+          <xsl:value-of select="substring-after(marc:subfield[@code='a'], ')')" />
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="marc:subfield[@code='a']" />
+        </xsl:otherwise>
+      </xsl:choose> 
+<xsl:if test="marc:subfield[@code='b'][1]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='b'][1]!=''"><xsl:value-of select="marc:subfield[@code='b'][1]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][1]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][1]!=''"><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][2]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][2]!=''"><xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][3]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][3]!=''"><xsl:value-of select="marc:subfield[@code='x'][3]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='t']!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='t']!=''"><xsl:value-of select="marc:subfield[@code='t']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='y'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='y']!=''"><xsl:value-of select="marc:subfield[@code='y']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='z'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='z']!=''"><xsl:value-of select="marc:subfield[@code='z']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='j'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='j']!=''"><xsl:value-of select="marc:subfield[@code='j']"/></xsl:if>
+</xsl:attribute>
+<xsl:attribute name="title">Lancer une recherche sur tous les mots sujet</xsl:attribute>
+<i class="fa fa-search"></i>
+</xsl:element>
+</span>
+</span>
+</xsl:for-each>
+
+<xsl:for-each select="marc:datafield[@tag=605]">
+<span class="results_summary subjects subject_tu">
+<span class="label">Sujet - Titre uniforme : </span>
+<span>
+<xsl:if test="marc:subfield[@code='a']">
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='a']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='a']"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='b']">
+<xsl:text>. </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='b'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='b'][1]"/></xsl:element>
+<xsl:if test="marc:subfield[@code='b'][2]">
+<xsl:text>. </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='b'][2]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='b'][2]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='b'][3]">
+<xsl:text>. </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='b'][3]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='b'][3]"/></xsl:element>
+</xsl:if>
+       </xsl:if>
+<xsl:if test="marc:subfield[@code='c']">
+<xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+ </xsl:if>
+<xsl:choose>
+<xsl:when test="(marc:subfield[@code='d']) and (marc:subfield[@code='f']) and (marc:subfield[@code='e'])">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:text> ; </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='f']"/>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='d']) and (marc:subfield[@code='f'])">
+ <xsl:text> ( </xsl:text>
+</xsl:when>
+<xsl:when test="marc:subfield[@code='d']">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+</xsl:choose>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='t']">
+<xsl:text> -- </xsl:text>
+<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='x']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:element>
+<xsl:if test="marc:subfield[@code='x'][2]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][2]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='x'][3]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][3]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][3]"/></xsl:element></xsl:if>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='y']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='y']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='y']"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='z']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='z']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='z']"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='2']">
+<xsl:text> -- </xsl:text>
+           <xsl:value-of select="marc:subfield[@code='2']"/>
+       </xsl:if>
+<xsl:text> | </xsl:text>
+<!-- recherche sur tous les mots -->
+<xsl:element name="a">
+<xsl:attribute name="href">
+<xsl:text>/cgi-bin/koha/catalogue/search.pl?idx=su&amp;q=</xsl:text>
+<xsl:choose>
+        <xsl:when test="contains(marc:subfield[@code='a'],'(')">
+          <xsl:value-of select="substring-before(marc:subfield[@code='a'], '(')" />
+          <xsl:value-of select="substring-before(substring-after(marc:subfield[@code='a'], '('), ')')" />
+          <xsl:value-of select="substring-after(marc:subfield[@code='a'], ')')" />
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="marc:subfield[@code='a']" />
+        </xsl:otherwise>
+      </xsl:choose> 
+<xsl:if test="marc:subfield[@code='b'][1]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='b'][1]!=''"><xsl:value-of select="marc:subfield[@code='b'][1]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][1]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][1]!=''"><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][2]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][2]!=''"><xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][3]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][3]!=''"><xsl:value-of select="marc:subfield[@code='x'][3]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='t']!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='t']!=''"><xsl:value-of select="marc:subfield[@code='t']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='y'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='y']!=''"><xsl:value-of select="marc:subfield[@code='y']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='z'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='z']!=''"><xsl:value-of select="marc:subfield[@code='z']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='j'] !=''"><xsl:text>+</xsl:text></xsl:if>
+<xsl:if test="marc:subfield[@code='j']!=''"><xsl:value-of select="marc:subfield[@code='j']"/></xsl:if>
+</xsl:attribute>
+<xsl:attribute name="title">Lancer une recherche sur tous les mots sujet</xsl:attribute>
+<i class="fa fa-search"></i>
+</xsl:element>
+</span>
+</span>
+</xsl:for-each>
+
+
+
+<!--&&11 Subject terms 606-->
+<xsl:for-each select="marc:datafield[@tag=606]">
+<span class="results_summary subjects subject_snc">
+<span class="label">Nom commun : </span>
+ <span>
+<xsl:if test="marc:subfield[@code='a']">
+            <xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='a']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='a']"/></xsl:element>
+       </xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='j']">
+<xsl:text> -- </xsl:text>
+            <xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='j'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='j'][1]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='x']">
+<xsl:text> -- </xsl:text>
+            <xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:element>
+<xsl:if test="marc:subfield[@code='x'][2]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][2]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='x'][3]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][3]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][3]"/></xsl:element>
+</xsl:if>
+       </xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='y']">
+<xsl:text> -- </xsl:text>
+ <xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='y'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='y'][1]"/></xsl:element>
+<xsl:if test="marc:subfield[@code='y'][2]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='y'][2]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='y'][2]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='y'][3]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='y'][3]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='y'][3]"/></xsl:element>
+</xsl:if>
+       </xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='z']">
+<xsl:text> -- </xsl:text>
+            <xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='z']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='z']"/></xsl:element>
+       </xsl:if>
+<xsl:if test="marc:subfield[@code='2']">
+<xsl:text> -- </xsl:text>
+           <xsl:value-of select="marc:subfield[@code='2']"/>
+       </xsl:if>
+<xsl:text> | </xsl:text>
+<!-- recherche sur tous les mots -->
+<xsl:element name="a">
+<xsl:attribute name="href">
+<xsl:text>/cgi-bin/koha/catalogue/search.pl?idx=su&amp;q=</xsl:text>
+<xsl:choose>
+        <xsl:when test="contains(marc:subfield[@code='a'],'(')">
+          <xsl:value-of select="substring-before(marc:subfield[@code='a'], '(')" />
+          <xsl:value-of select="substring-before(substring-after(marc:subfield[@code='a'], '('), ')')" />
+          <xsl:value-of select="substring-after(marc:subfield[@code='a'], ')')" />
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="marc:subfield[@code='a']" />
+        </xsl:otherwise>
+      </xsl:choose> 
+<xsl:if test="marc:subfield[@code='x'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][1]!=''"><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:if> <xsl:if test="marc:subfield[@code='x'][2]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][2]!=''"> <xsl:value-of select="marc:subfield[@code='x'][2]"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='x'][3]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][3]!=''"><xsl:value-of select="marc:subfield[@code='x'][3]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='y'][1] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='y'][1] !=''"><xsl:value-of select="marc:subfield[@code='y'][1]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='y'][2] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='y'][2] !=''"><xsl:value-of select="marc:subfield[@code='y'][2]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='y'][3] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='y'][3] !=''"><xsl:value-of select="marc:subfield[@code='y'][3]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='z'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='z']!=''"><xsl:value-of select="marc:subfield[@code='z']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='j'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='j']!=''"><xsl:value-of select="marc:subfield[@code='j']"/></xsl:if>
+</xsl:attribute>
+<xsl:attribute name="title">Lancer une recherche sur tous les mots sujet</xsl:attribute>
+<i class="fa fa-search"></i>
+</xsl:element>
+</span>
+ </span>
+ </xsl:for-each>
+
+
+<!--&&12 Subject geographic name 607-->
+<xsl:for-each select="marc:datafield[@tag=607]">
+<span class="results_summary subjects subject_sng">
+<span class="label">Nom géographique : </span>
+ <span>
+<xsl:if test="marc:subfield[@code='a']">
+            <xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='a']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='a']"/></xsl:element>
+       </xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='x']">
+<xsl:text> -- </xsl:text>
+            <xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:element>
+<xsl:if test="marc:subfield[@code='x'][2]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][2]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='x'][3]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][3]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][3]"/></xsl:element>
+</xsl:if>
+ </xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='y']">
+<xsl:text> -- </xsl:text>
+            <xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='y'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='y'][1]"/></xsl:element>
+<xsl:if test="marc:subfield[@code='y'][2]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='y'][2]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='y'][2]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='y'][3]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='y'][3]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='y'][3]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='y'][4]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='y'][4]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='y'][4]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='y'][5]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='y'][5]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='y'][5]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='y'][6]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='y'][6]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='y'][6]"/></xsl:element>
+</xsl:if>     
+ </xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='z']">
+<xsl:text> -- </xsl:text>
+            <xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='z']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='z']"/></xsl:element>
+       </xsl:if>
+<xsl:if test="marc:subfield[@code='2']">
+<xsl:text> -- </xsl:text>
+           <xsl:value-of select="marc:subfield[@code='2']"/>
+       </xsl:if>
+<xsl:text> | </xsl:text>
+<!-- recherche sur tous les mots -->
+<xsl:element name="a">
+<xsl:attribute name="href">
+<xsl:text>/cgi-bin/koha/catalogue/search.pl?idx=su&amp;q=</xsl:text>
+<xsl:choose>
+        <xsl:when test="contains(marc:subfield[@code='a'],'(')">
+          <xsl:value-of select="substring-before(marc:subfield[@code='a'], '(')" />
+          <xsl:value-of select="substring-before(substring-after(marc:subfield[@code='a'], '('), ')')" />
+          <xsl:value-of select="substring-after(marc:subfield[@code='a'], ')')" />
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="marc:subfield[@code='a']" />
+        </xsl:otherwise>
+      </xsl:choose> 
+<xsl:if test="marc:subfield[@code='x'][1]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][1]!=''"><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][2]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][2]!=''"><xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][3]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][3]!=''"><xsl:value-of select="marc:subfield[@code='x'][3]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='y'][1] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='y'][1] !=''"><xsl:value-of select="marc:subfield[@code='y'][1]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='y'][2] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='y'][2] !=''"><xsl:value-of select="marc:subfield[@code='y'][2]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='y'][3] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='y'][3] !=''"><xsl:value-of select="marc:subfield[@code='y'][3]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='z'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='z']!=''"><xsl:value-of select="marc:subfield[@code='z']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='j'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='j']!=''"><xsl:value-of select="marc:subfield[@code='j']"/></xsl:if>
+</xsl:attribute>
+<xsl:attribute name="title">Lancer une recherche sur tous les mots sujet</xsl:attribute>
+<i class="fa fa-search"></i>
+</xsl:element>
+</span>
+ </span>
+ </xsl:for-each>
+
+<xsl:for-each select="marc:datafield[@tag=608]">
+<span class="results_summary subjects subject_genre_form">
+<span class="label">Sujet - Forme, genre, caractéristiques physiques : </span>
+<span>
+<xsl:if test="marc:subfield[@code='a']">
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='a']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='a']"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='b']">
+<xsl:text>. </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='b'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='b'][1]"/></xsl:element>
+<xsl:if test="marc:subfield[@code='b'][2]">
+<xsl:text>. </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='b'][2]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='b'][2]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='b'][3]">
+<xsl:text>. </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='b'][3]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='b'][3]"/></xsl:element>
+</xsl:if>
+       </xsl:if>
+<xsl:if test="marc:subfield[@code='c']">
+<xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+ </xsl:if>
+<xsl:choose>
+<xsl:when test="(marc:subfield[@code='d']) and (marc:subfield[@code='f']) and (marc:subfield[@code='e'])">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:text> ; </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='f']"/>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='d']) and (marc:subfield[@code='f'])">
+ <xsl:text> ( </xsl:text>
+</xsl:when>
+<xsl:when test="marc:subfield[@code='d']">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+</xsl:choose>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='t']">
+<xsl:text> -- </xsl:text>
+<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='x']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:element>
+<xsl:if test="marc:subfield[@code='x'][2]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][2]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='x'][3]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][3]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][3]"/></xsl:element></xsl:if>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='y']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='y']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='y']"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='z']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/catalogue/search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='z']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='z']"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='2']">
+<xsl:text> -- </xsl:text>
+           <xsl:value-of select="marc:subfield[@code='2']"/>
+       </xsl:if>
+<xsl:text> | </xsl:text>
+<!-- recherche sur tous les mots -->
+<xsl:element name="a">
+<xsl:attribute name="href">
+<xsl:text>/cgi-bin/koha/catalogue/search.pl?idx=su&amp;q=</xsl:text>
+<xsl:choose>
+        <xsl:when test="contains(marc:subfield[@code='a'],'(')">
+          <xsl:value-of select="substring-before(marc:subfield[@code='a'], '(')" />
+          <xsl:value-of select="substring-before(substring-after(marc:subfield[@code='a'], '('), ')')" />
+          <xsl:value-of select="substring-after(marc:subfield[@code='a'], ')')" />
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="marc:subfield[@code='a']" />
+        </xsl:otherwise>
+</xsl:choose>
+<xsl:if test="marc:subfield[@code='b'][1]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='b'][1]!=''"><xsl:value-of select="marc:subfield[@code='b'][1]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][1]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][1]!=''"><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][2]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][2]!=''"><xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][3]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][3]!=''"><xsl:value-of select="marc:subfield[@code='x'][3]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='t'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='t']!=''"><xsl:value-of select="marc:subfield[@code='t']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='y'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='y']!=''"><xsl:value-of select="marc:subfield[@code='y']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='z'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='z']!=''"><xsl:value-of select="marc:subfield[@code='z']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='j'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='j']!=''"><xsl:value-of select="marc:subfield[@code='j']"/></xsl:if>
+</xsl:attribute>
+<xsl:attribute name="title">Lancer une recherche sur tous les mots sujet</xsl:attribute>
+<i class="fa fa-search"></i>
+</xsl:element>
+</span>
+</span>
+</xsl:for-each>
+
+
+ <xsl:call-template name="tag_subject">
+ <xsl:with-param name="tag">615</xsl:with-param>
+ <xsl:with-param name="label">Catégorie de sujet</xsl:with-param>
+ </xsl:call-template>
+
+ <xsl:call-template name="tag_subject">
+ <xsl:with-param name="tag">616</xsl:with-param>
+ <xsl:with-param name="label">Marque commerciale</xsl:with-param>
+ </xsl:call-template>
+
+<!--&&14 URL 856-->
+<xsl:if test="marc:datafield[@tag=856]/marc:subfield[@code='u']">
+      <span class="results_summary online_resources">
+        <span class="label">Ressource en ligne : </span>
+        <xsl:for-each select="marc:datafield[@tag=856]">
+ <xsl:variable name="url" select="substring-before(marc:subfield[@code='u'], '//')"/>
+<xsl:if test="contains($url,'http:') or contains($url,'https:')">
+          <a>
+            <xsl:attribute name="href">
+              <xsl:value-of select="marc:subfield[@code='u']"/>
+            </xsl:attribute>
+            <xsl:choose>
+              <xsl:when test="marc:subfield[@code='y' or @code='3' or @code='z']">
+                <xsl:call-template name="subfieldSelect">
+                  <xsl:with-param name="codes">y3z</xsl:with-param>
+                </xsl:call-template>
+              </xsl:when>
+              <xsl:when test="not(marc:subfield[@code='y']) and not(marc:subfield[@code='3']) and not(marc:subfield[@code='z'])">
+              Cliquer ici
+            </xsl:when>
+            </xsl:choose>
+          </a>
+</xsl:if>
+<xsl:if test="not(contains($url,'http:')) and not (contains($url,'https:'))">
+          <a>
+            <xsl:attribute name="href">
+              http://<xsl:value-of select="marc:subfield[@code='u']"/>
+            </xsl:attribute>
+            <xsl:choose>
+              <xsl:when test="marc:subfield[@code='y' or @code='3' or @code='z']">
+                <xsl:call-template name="subfieldSelect">
+                  <xsl:with-param name="codes">y3z</xsl:with-param>
+                </xsl:call-template>
+              </xsl:when>
+              <xsl:when test="not(marc:subfield[@code='y']) and not(marc:subfield[@code='3']) and not(marc:subfield[@code='z'])">
+              Cliquer ici
+            </xsl:when>
+            </xsl:choose>
+          </a>
+</xsl:if>
+          <xsl:choose>
+            <xsl:when test="position()=last()"/>
+            <xsl:otherwise> | </xsl:otherwise>
+          </xsl:choose>
+        </xsl:for-each>
+      </span>
+    </xsl:if>
+ 
+<!--<xsl:if test="marc:datafield[@tag=901]">
+ <span class="results_summary">
+ <span class="label">Genre : </span>
+ <xsl:for-each select="marc:datafield[@tag=901]">
+ <xsl:for-each select="marc:subfield">
+ <xsl:value-of select="text()"/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text>.</xsl:text>
+ </xsl:when>
+ <xsl:otherwise><xsl:text>, </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+ </xsl:for-each>
+ </span>
+ </xsl:if>-->
+
+
+ <!-- 780 -->
+ <xsl:if test="marc:datafield[@tag=780]">
+ <xsl:for-each select="marc:datafield[@tag=780]">
+ <span class="results_summary preceeding_entry">
+ <xsl:choose>
+ <xsl:when test="@ind2=0">
+ <span class="label">Continue : </span>
+ </xsl:when>
+ <xsl:when test="@ind2=1">
+ <span class="label">Continue en partie : </span>
+ </xsl:when>
+ <xsl:when test="@ind2=2">
+ <span class="label">Remplace : </span>
+ </xsl:when>
+ <xsl:when test="@ind2=3">
+ <span class="label">Remplace partiellement : </span>
+ </xsl:when>
+ <xsl:when test="@ind2=4">
+ <span class="label">Formé par la réunion de ... et : ...</span>
+ </xsl:when>
+ <xsl:when test="@ind2=5">
+ <span class="label">Absorbé : </span>
+ </xsl:when>
+ <xsl:when test="@ind2=6">
+ <span class="label">Absorbé en partie : </span>
+ </xsl:when>
+ <xsl:when test="@ind2=7">
+ <span class="label">Séparé de : </span>
+ </xsl:when>
+ </xsl:choose>
+ <xsl:variable name="f780">
+ <xsl:call-template name="subfieldSelect">
+ <xsl:with-param name="codes">a</xsl:with-param>
+ </xsl:call-template>
+ </xsl:variable>
+ <a><xsl:attribute name="href">/cgi-bin/koha/catalogue/search.pl?q=<xsl:value-of select="translate($f780, '()', '')"/></xsl:attribute>
+ <xsl:value-of select="translate($f780, '()', '')"/>
+ </a>
+ </span>
+ <xsl:choose>
+ <xsl:when test="@ind1=0">
+ <span class="results_summary">
+ <xsl:value-of select="marc:subfield[@code='n']"/>
+ </span>
+ </xsl:when>
+ </xsl:choose>
+ </xsl:for-each>
+ </xsl:if>
+
+ <!-- 785 -->
+ <xsl:if test="marc:datafield[@tag=785]">
+ <xsl:for-each select="marc:datafield[@tag=785]">
+ <span class="results_summary succeeding_entry">
+ <xsl:choose>
+ <xsl:when test="@ind2=0">
+ <span class="label">Continué par : </span>
+ </xsl:when>
+ <xsl:when test="@ind2=1">
+ <span class="label">Continué partiellement par : </span>
+ </xsl:when>
+ <xsl:when test="@ind2=2">
+ <span class="label">Remplacé par : </span>
+ </xsl:when>
+ <xsl:when test="@ind2=3">
+ <span class="label">Partiellement remplacé par : </span>
+ </xsl:when>
+ <xsl:when test="@ind2=4">
+ <span class="label">Absorbé par : </span>
+ </xsl:when>
+ <xsl:when test="@ind2=5">
+ <span class="label">Absorbé partiellement par : </span>
+ </xsl:when>
+ <xsl:when test="@ind2=6">
+ <span class="label">Eclater de ... à ... : </span>
+ </xsl:when>
+ <xsl:when test="@ind2=7">
+ <span class="label">Fusionné avec ... pour former ...</span>
+ </xsl:when>
+ <xsl:when test="@ind2=8">
+ <span class="label">Redevient : </span>
+ </xsl:when>
+ </xsl:choose>
+ <xsl:variable name="f785">
+ <xsl:call-template name="subfieldSelect">
+ <xsl:with-param name="codes">à</xsl:with-param>
+ </xsl:call-template>
+ </xsl:variable>
+ <a><xsl:attribute name="href">/cgi-bin/koha/catalogue/search.pl?q=<xsl:value-of select="translate($f785, '()', '')"/></xsl:attribute>
+ <xsl:value-of select="translate($f785, '()', '')"/>
+ </a>
+ </span>
+ </xsl:for-each>
+ </xsl:if>
+
+ </xsl:template>
+
+ <xsl:template name="nameABCDQ">
+ <xsl:call-template name="chopPunctuation">
+ <xsl:with-param name="chopString">
+ <xsl:call-template name="subfieldSelect">
+ <xsl:with-param name="codes">aq</xsl:with-param>
+ </xsl:call-template>
+ </xsl:with-param>
+ <xsl:with-param name="punctuation">
+ <xsl:text>:,;/ </xsl:text>
+ </xsl:with-param>
+ </xsl:call-template>
+ <xsl:call-template name="termsOfAddress"/>
+ </xsl:template>
+
+ <xsl:template name="nameABCDN">
+ <xsl:for-each select="marc:subfield[@code='a']">
+ <xsl:call-template name="chopPunctuation">
+ <xsl:with-param name="chopString" select="."/>
+ </xsl:call-template>
+ </xsl:for-each>
+ <xsl:for-each select="marc:subfield[@code='b']">
+ <xsl:value-of select="."/>
+ </xsl:for-each>
+ <xsl:if test="marc:subfield[@code='c'] or marc:subfield[@code='d'] or marc:subfield[@code='n']">
+ <xsl:call-template name="subfieldSelect">
+ <xsl:with-param name="codes">cdn</xsl:with-param>
+ </xsl:call-template>
+ </xsl:if>
+ </xsl:template>
+
+ <xsl:template name="nameACDEQ">
+ <xsl:call-template name="subfieldSelect">
+ <xsl:with-param name="codes">acdeq</xsl:with-param>
+ </xsl:call-template>
+ </xsl:template>
+ <xsl:template name="termsOfAddress">
+ <xsl:if test="marc:subfield[@code='b' or @code='c']">
+ <xsl:call-template name="chopPunctuation">
+ <xsl:with-param name="chopString">
+ <xsl:call-template name="subfieldSelect">
+ <xsl:with-param name="codes">bc</xsl:with-param>
+ </xsl:call-template>
+ </xsl:with-param>
+ </xsl:call-template>
+ </xsl:if>
+ </xsl:template>
+
+ <xsl:template name="part">
+ <xsl:variable name="partNumber">
+ <xsl:call-template name="specialSubfieldSelect">
+ <xsl:with-param name="axis">n</xsl:with-param>
+ <xsl:with-param name="anyCodes">n</xsl:with-param>
+ <xsl:with-param name="afterCodes">fghkdlmor</xsl:with-param>
+ </xsl:call-template>
+ </xsl:variable>
+ <xsl:variable name="partName">
+ <xsl:call-template name="specialSubfieldSelect">
+ <xsl:with-param name="axis">p</xsl:with-param>
+ <xsl:with-param name="anyCodes">p</xsl:with-param>
+ <xsl:with-param name="afterCodes">fghkdlmor</xsl:with-param>
+ </xsl:call-template>
+ </xsl:variable>
+ <xsl:if test="string-length(normalize-space($partNumber))">
+ <xsl:call-template name="chopPunctuation">
+ <xsl:with-param name="chopString" select="$partNumber"/>
+ </xsl:call-template>
+ </xsl:if>
+ <xsl:if test="string-length(normalize-space($partName))">
+ <xsl:call-template name="chopPunctuation">
+ <xsl:with-param name="chopString" select="$partName"/>
+ </xsl:call-template>
+ </xsl:if>
+ </xsl:template>
+
+ <xsl:template name="specialSubfieldSelect">
+ <xsl:param name="anyCodes"/>
+ <xsl:param name="axis"/>
+ <xsl:param name="beforeCodes"/>
+ <xsl:param name="afterCodes"/>
+ <xsl:variable name="str">
+ <xsl:for-each select="marc:subfield">
+ <xsl:if test="contains($anyCodes, @code)      or (contains($beforeCodes,@code) and following-sibling::marc:subfield[@code=$axis])      or (contains($afterCodes,@code) and preceding-sibling::marc:subfield[@code=$axis])">
+ <xsl:value-of select="text()"/>
+ <xsl:text> </xsl:text>
+ </xsl:if>
+ </xsl:for-each>
+ </xsl:variable>
+ <xsl:value-of select="substring($str,1,string-length($str)-1)"/>
+ </xsl:template>
+
+</xsl:stylesheet>

--- a/biblibre/intranet/UNIMARCslim2intranetResults.xsl
+++ b/biblibre/intranet/UNIMARCslim2intranetResults.xsl
@@ -1,0 +1,424 @@
+<!-- $Id: MARC21slim2DC.xsl,v 1.1 2003/01/06 08:20:27 adam Exp $ -->
+<xsl:stylesheet version="1.0"
+  xmlns:marc="http://www.loc.gov/MARC21/slim"
+  xmlns:items="http://www.koha-community.org/items"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  exclude-result-prefixes="marc items">
+<xsl:import href="UNIMARCslimUtils.xsl"/>
+<xsl:output method = "html" indent="yes" omit-xml-declaration = "yes" encoding="UTF-8"/>
+<xsl:key name="item-by-status" match="items:item" use="items:status"/>
+<xsl:key name="item-by-status-and-branch" match="items:item" use="concat(items:status, ' ', items:homebranch)"/>
+
+<xsl:template match="/">
+<xsl:apply-templates/>
+</xsl:template>
+
+<xsl:template match="marc:record">
+<xsl:variable name="IntranetBiblioDefaultView" select="marc:sysprefs/marc:syspref[@name='IntranetBiblioDefaultView']"/>
+<xsl:variable name="leader" select="marc:leader"/>
+<xsl:variable name="leader6" select="substring($leader,7,1)"/>
+<xsl:variable name="leader7" select="substring($leader,8,1)"/>
+<xsl:variable name="biblionumber" select="marc:controlfield[@tag=001]"/>
+<xsl:variable name="isbn" select="marc:datafield[@tag=010]/marc:subfield[@code='a']"/>
+<xsl:variable name="renvoi" select="marc:datafield[@tag=700]/@ind1"/>
+<xsl:variable name="type_doc" select="marc:datafield[@tag=099]/marc:subfield[@code='t']"/>
+
+<xsl:if test="marc:datafield[@tag=200]">
+<xsl:for-each select="marc:datafield[@tag=200]">
+<a>
+<xsl:attribute name="href">
+<xsl:call-template name="buildBiblioDefaultViewURL">
+<xsl:with-param name="IntranetBiblioDefaultView">
+<xsl:value-of select="$IntranetBiblioDefaultView"/>
+</xsl:with-param>
+</xsl:call-template>
+<xsl:value-of select="$biblionumber"/>
+</xsl:attribute>
+<xsl:attribute name="class">title</xsl:attribute>
+<xsl:variable name="title" select="marc:subfield[@code='a']"/>
+<xsl:variable name="ntitle"
+select="translate($title, '&#x0098;&#x009C;&#xC29C;&#xC29B;&#xC298;&#xC288;&#xC289;','')"/>
+<xsl:value-of select="$ntitle" />
+</a>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='b']">
+<xsl:text> [</xsl:text>
+<xsl:value-of select="marc:subfield[@code='b']"/>
+<xsl:text>]</xsl:text>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='h']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='h']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='i']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='i']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='f']">
+<xsl:text> / </xsl:text>
+<xsl:value-of select="marc:subfield[@code='f']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text> </xsl:text>
+</xsl:for-each>
+</xsl:if>
+
+<xsl:if test="marc:datafield[@tag=700]">
+<xsl:if test="not(contains($renvoi,'z'))">
+<span class="results_summary author main_author">
+<span class="label">Auteur : </span>
+<xsl:for-each select="marc:datafield[@tag=700]">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:if test="marc:subfield[@code='b']">
+<xsl:text> , </xsl:text>
+<xsl:value-of select="marc:subfield[@code='b']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='f']">
+<xsl:text> ( </xsl:text>
+<xsl:value-of select="marc:subfield[@code='f']"/>
+<xsl:text> ) </xsl:text>
+</xsl:if>
+<xsl:text> </xsl:text>
+</xsl:for-each>
+</span>
+</xsl:if>
+</xsl:if>
+
+
+<xsl:if test="marc:datafield[@tag=710]">
+<span class="results_summary author corporate_main_author">
+<span class="label">Collectivité Auteur : </span>
+<xsl:for-each select="marc:datafield[@tag=710]">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:if test="marc:subfield[@code='b']">
+<xsl:text> , </xsl:text>
+<xsl:value-of select="marc:subfield[@code='b']"/>
+</xsl:if>
+</xsl:for-each>
+</span>
+</xsl:if>
+
+<!--Titre de serie - autorité 461-->
+<!--<xsl:call-template name="tag_461" />-->
+
+<!--Titre de série - non autorité 461-->
+<xsl:call-template name="tag_461bis" />
+
+<!--Titre  dépouillé 463-->
+<xsl:call-template name="tag_463" />
+
+<xsl:if test="contains($type_doc,'Revue')">
+<xsl:call-template name="tag_462" />
+</xsl:if>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">412</xsl:with-param>
+<xsl:with-param name="label">Est un extrait ou tiré à part de</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">413</xsl:with-param>
+<xsl:with-param name="label">A pour extrait ou tiré à part</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">421</xsl:with-param>
+<xsl:with-param name="label">A pour supplément</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">423</xsl:with-param>
+<xsl:with-param name="label">Est un supplément de</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">423</xsl:with-param>
+<xsl:with-param name="label">Est publié avec</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">424</xsl:with-param>
+<xsl:with-param name="label">Est mis à jour par</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">430</xsl:with-param>
+<xsl:with-param name="label">Suite de</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">431</xsl:with-param>
+<xsl:with-param name="label">Succède après scission à</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">432</xsl:with-param>
+<xsl:with-param name="label">Remplace</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">433</xsl:with-param>
+<xsl:with-param name="label">Remplace partiellement</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">434</xsl:with-param>
+<xsl:with-param name="label">Absorbe</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">435</xsl:with-param>
+<xsl:with-param name="label">Absorbe partiellement</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">436</xsl:with-param>
+<xsl:with-param name="label">Fusion de</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">437</xsl:with-param>
+<xsl:with-param name="label">Suite partielle de</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">440</xsl:with-param>
+<xsl:with-param name="label">Devient</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">441</xsl:with-param>
+<xsl:with-param name="label">Devient partiellement</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">442</xsl:with-param>
+<xsl:with-param name="label">Remplacé par</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">443</xsl:with-param>
+<xsl:with-param name="label">Remplacé partiellement par</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">444</xsl:with-param>
+<xsl:with-param name="label">Absorbé par</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">447</xsl:with-param>
+<xsl:with-param name="label">Fusionné avec...pour former</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">451</xsl:with-param>
+<xsl:with-param name="label">A pour autre édition, sur le même support</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">452</xsl:with-param>
+<xsl:with-param name="label">A pour autre édition, sur un support différent</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">453</xsl:with-param>
+<xsl:with-param name="label">Traduit sous le titre</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">454</xsl:with-param>
+<xsl:with-param name="label">Est une traduction de</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">455</xsl:with-param>
+<xsl:with-param name="label">Est une reproduction de</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">456</xsl:with-param>
+<xsl:with-param name="label">Est reproduit comme</xsl:with-param>
+</xsl:call-template>
+
+<!--masqué car risque de longues listes de titres en résultats-->
+<!--<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">464</xsl:with-param>
+<xsl:with-param name="label">Composante</xsl:with-param>
+</xsl:call-template>-->
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">470</xsl:with-param>
+<xsl:with-param name="label">Document analysé</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">482</xsl:with-param>
+<xsl:with-param name="label">Relié à la suite de</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">488</xsl:with-param>
+<xsl:with-param name="label">Autre type de relation</xsl:with-param>
+</xsl:call-template>
+
+<xsl:if test="marc:datafield[@tag=099]/marc:subfield[@code='t']">
+  <span class="results_summary typedoc">
+    <span class="label">Catégorie de document : </span>
+    <xsl:for-each select="marc:datafield[@tag=099]/marc:subfield[@code='t']">
+      <xsl:value-of select="."/>
+      <xsl:if test="not(position()=last())"><xsl:text> ; </xsl:text></xsl:if>
+    </xsl:for-each>
+  </span>
+</xsl:if>
+
+
+<xsl:if test="(marc:datafield[@tag=214] or marc:datafield[@tag=210])">
+<xsl:choose>
+<xsl:when test="(marc:datafield[@tag=214]/marc:subfield[@code='r'])">
+<xsl:call-template name="tag_214_r" />
+</xsl:when>
+<xsl:when test="(marc:datafield[@tag=214]/marc:subfield[@code='s'])">
+<xsl:call-template name="tag_214_s" />
+</xsl:when>
+<xsl:when test="(marc:datafield[@tag=210]/marc:subfield[@code='r'])">
+<xsl:call-template name="tag_210_r" />
+</xsl:when>
+<xsl:when test="(marc:datafield[@tag=210]/marc:subfield[@code='s'])">
+<xsl:call-template name="tag_210_s" />
+</xsl:when>
+<xsl:when test="(marc:datafield[@tag=214] and  marc:datafield[@tag=210])">
+<xsl:call-template name="tag_214" />
+</xsl:when>
+<xsl:when test="(marc:datafield[@tag=214])">
+<xsl:call-template name="tag_214" />
+</xsl:when>
+<xsl:when test="(marc:datafield[@tag=210])">
+<xsl:call-template name="tag_210" />
+</xsl:when>
+</xsl:choose>
+</xsl:if>
+
+<xsl:call-template name="tag_215" />
+
+<!--Collection autorité 410-->
+<!--<xsl:for-each select="marc:datafield[@tag=410]">
+<span class="results_summary">
+<span class="label">Collection Autorité : </span>
+<xsl:element name="a"><xsl:attribute name="href">
+/cgi-bin/koha/catalogue/search.pl?q=an:<xsl:value-of select="marc:subfield[@code='9']"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:element>
+<xsl:if test="marc:subfield[@code='t'] and marc:subfield[@code='v']">
+<xsl:text> . </xsl:text>
+<xsl:value-of select="marc:subfield[@code='v']"/>
+</xsl:if>
+</span>
+</xsl:for-each>-->
+
+
+<!--Etat de collection-->
+<xsl:if test="marc:datafield[@tag=923]">
+    <dt class="prolabelxslt">État des collections</dt>
+          <xsl:for-each select="marc:datafield[@tag=923]">
+<xsl:if test="marc:subfield[@code='r']">
+            <dd>
+              <xsl:if test="marc:subfield[@code='b']">
+                        <xsl:call-template name="RCR">
+                              <xsl:with-param name="code" select="marc:subfield[@code='b']"/>
+                        </xsl:call-template>
+                  </xsl:if>
+                      <xsl:if test="marc:subfield[@code='r']">
+                  <xsl:text> </xsl:text>
+                  <span class="statutdispo">
+                                <xsl:value-of select="marc:subfield[@code='r']"/>
+                  </span>
+                      </xsl:if>
+                <xsl:if test="marc:subfield[@code='a']">
+                  <xsl:text> (Cote : </xsl:text>
+                  <xsl:value-of select="marc:subfield[@code='a']" />
+                  <xsl:text>)</xsl:text>
+                </xsl:if>
+
+                <xsl:if test="marc:subfield[@code='c']">
+                  <xsl:text> Localisation : </xsl:text>
+                  <xsl:value-of select="marc:subfield[@code='c']" />
+
+                </xsl:if>
+
+              </dd>
+</xsl:if>
+
+          </xsl:for-each>
+</xsl:if>
+
+<xsl:if test="marc:datafield[@tag=856]/marc:subfield[@code='u']">
+  <span class="results_summary online_resources">
+    <span class="label">Online resources : </span>
+        <xsl:for-each select="marc:datafield[@tag=856]">
+ <xsl:variable name="url" select="substring-before(marc:subfield[@code='u'], '//')"/>
+<xsl:if test="contains($url,'http:') or contains($url,'https:')">
+          <a>
+            <xsl:attribute name="href">
+              <xsl:value-of select="marc:subfield[@code='u']"/>
+            </xsl:attribute>
+            <xsl:choose>
+              <xsl:when test="marc:subfield[@code='y' or @code='3' or @code='z']">
+                <xsl:call-template name="subfieldSelect">
+                  <xsl:with-param name="codes">y3z</xsl:with-param>
+                </xsl:call-template>
+              </xsl:when>
+              <xsl:when test="not(marc:subfield[@code='y']) and not(marc:subfield[@code='3']) and not(marc:subfield[@code='z'])">
+              Cliquer ici
+            </xsl:when>
+            </xsl:choose>
+          </a>
+</xsl:if>
+<xsl:if test="not(contains($url,'http:')) and not (contains($url,'https:'))">
+          <a>
+            <xsl:attribute name="href">
+              http://<xsl:value-of select="marc:subfield[@code='u']"/>
+            </xsl:attribute>
+            <xsl:choose>
+              <xsl:when test="marc:subfield[@code='y' or @code='3' or @code='z']">
+                <xsl:call-template name="subfieldSelect">
+                  <xsl:with-param name="codes">y3z</xsl:with-param>
+                </xsl:call-template>
+              </xsl:when>
+              <xsl:when test="not(marc:subfield[@code='y']) and not(marc:subfield[@code='3']) and not(marc:subfield[@code='z'])">
+              Cliquer ici
+</xsl:when>
+ </xsl:choose>
+          </a>
+</xsl:if>
+          <xsl:choose>
+            <xsl:when test="position()=last()"/>
+            <xsl:otherwise> | </xsl:otherwise>
+          </xsl:choose>
+        </xsl:for-each>
+      </span>
+    </xsl:if>
+
+
+<!--public 995$q-->
+<!--
+<xsl:call-template name="public" />
+-->
+
+
+<!--Fonds  995h-->
+<!--
+<xsl:call-template name="fonds" />
+-->
+
+
+</xsl:template>
+
+</xsl:stylesheet>

--- a/biblibre/intranet/UNIMARCslimUtils.xsl
+++ b/biblibre/intranet/UNIMARCslimUtils.xsl
@@ -1,0 +1,1534 @@
+<xsl:stylesheet version="1.0"
+  xmlns:marc="http://www.loc.gov/MARC21/slim"
+  xmlns:items="http://www.koha-community.org/items"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  exclude-result-prefixes="marc items">
+
+<xsl:template name="datafield">
+<xsl:param name="tag"/>
+<xsl:param name="ind1"><xsl:text> </xsl:text></xsl:param>
+<xsl:param name="ind2"><xsl:text> </xsl:text></xsl:param>
+<xsl:param name="subfields"/>
+<xsl:element name="datafield">
+<xsl:attribute name="tag">
+<xsl:value-of select="$tag"/>
+</xsl:attribute>
+<xsl:attribute name="ind1">
+<xsl:value-of select="$ind1"/>
+</xsl:attribute>
+<xsl:attribute name="ind2">
+<xsl:value-of select="$ind2"/>
+</xsl:attribute>
+<xsl:copy-of select="$subfields"/>
+</xsl:element>
+</xsl:template>
+
+
+<xsl:template name="tag_210">
+<xsl:for-each select="marc:datafield[@tag=210]">
+<span class="results_summary publisher">
+<span class="label">Publication : </span>
+<xsl:choose>
+<xsl:when test="(marc:subfield[@code='a'][2]) and (marc:subfield[@code='c'][2]) and (marc:subfield[@code='d'])">
+<xsl:value-of select="marc:subfield[@code='a'][1]"/>
+<xsl:text> : </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+<xsl:text>/cgi-bin/koha/catalogue/search.pl?idx=Publisher&amp;q=</xsl:text>
+<xsl:value-of select="marc:subfield[@code='c'][1]"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c'][1]"/>
+</xsl:element>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='a'][2]"/>
+<xsl:text> : </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+<xsl:text>/cgi-bin/koha/catalogue/search.pl?idx=Publisher&amp;q=</xsl:text>
+<xsl:value-of select="marc:subfield[@code='c'][2]"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c'][2]"/>
+</xsl:element>
+<xsl:if test="marc:subfield[@code='a'][3]">
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='a'][3]"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='c'][3]">
+<xsl:text> : </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+<xsl:text>/cgi-bin/koha/catalogue/search.pl?idx=Publisher&amp;q=</xsl:text>
+<xsl:value-of select="marc:subfield[@code='c'][3]"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c'][3]"/>
+</xsl:element>
+</xsl:if>
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='c'][2]) and (marc:subfield[@code='d'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:if test="position()!=last()">
+<xsl:text> ; </xsl:text>
+</xsl:if>
+<xsl:if test="position()=last()">
+<xsl:text> : </xsl:text>
+</xsl:if>
+<xsl:for-each select="marc:subfield[@code='c']">
+<xsl:element name="a">
+<xsl:attribute name="href">
+<xsl:text>/cgi-bin/koha/catalogue/search.pl?idx=Publisher&amp;q=</xsl:text>
+<xsl:value-of select="text()"/>
+</xsl:attribute>
+<xsl:value-of select="text()"/>
+</xsl:element>
+<xsl:if test="position()!=last()">
+<xsl:text> : </xsl:text>
+</xsl:if>
+<xsl:if test="position()=last()">
+<xsl:text></xsl:text>
+</xsl:if>
+</xsl:for-each>
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a'][2]) and (marc:subfield[@code='c']) and (marc:subfield[@code='d'])">
+<xsl:for-each select="marc:subfield[@code='a']">
+<xsl:value-of select="text()"/>
+<xsl:if test="position()!=last()">
+<xsl:text> ; </xsl:text>
+</xsl:if>
+<xsl:if test="position()=last()">
+<xsl:text> : </xsl:text>
+</xsl:if>
+</xsl:for-each>
+<xsl:element name="a">
+<xsl:attribute name="href">
+<xsl:text>/cgi-bin/koha/catalogue/search.pl?idx=Publisher&amp;q=</xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:element>
+<xsl:if test="position()!=last()">
+<xsl:text> : </xsl:text>
+</xsl:if>
+<xsl:if test="position()=last()">
+<xsl:text></xsl:text>
+</xsl:if>
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='c']) and (marc:subfield[@code='d'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text> : </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+<xsl:text>/cgi-bin/koha/catalogue/search.pl?idx=Publisher&amp;q=</xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:element>
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='c'][2])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text> : </xsl:text>
+<xsl:for-each select="marc:subfield[@code='c']">
+<xsl:element name="a">
+<xsl:attribute name="href">
+<xsl:text>/cgi-bin/koha/catalogue/search.pl?idx=Publisher&amp;q=</xsl:text>
+<xsl:value-of select="text()"/>
+</xsl:attribute>
+<xsl:value-of select="text()"/>
+</xsl:element>
+<xsl:if test="position()!=last()">
+<xsl:text> : </xsl:text>
+</xsl:if>
+<xsl:if test="position()=last()">
+<xsl:text></xsl:text>
+</xsl:if>
+</xsl:for-each>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='c'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text> : </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+<xsl:text>/cgi-bin/koha/catalogue/search.pl?idx=Publisher&amp;q=</xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:element>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='c'][2]) and (marc:subfield[@code='d'])">
+<xsl:for-each select="marc:subfield[@code='c']">
+<xsl:element name="a">
+<xsl:attribute name="href">
+<xsl:text>/cgi-bin/koha/catalogue/search.pl?idx=Publisher&amp;q=</xsl:text>
+<xsl:value-of select="text()"/>
+</xsl:attribute>
+<xsl:value-of select="text()"/>
+</xsl:element>
+<xsl:if test="position()!=last()">
+<xsl:text> : </xsl:text>
+</xsl:if>
+<xsl:if test="position()=last()">
+<xsl:text>, </xsl:text>
+</xsl:if>
+</xsl:for-each>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='c']) and (marc:subfield[@code='d'])">
+<xsl:element name="a">
+<xsl:attribute name="href">
+<xsl:text>/cgi-bin/koha/catalogue/search.pl?idx=Publisher&amp;q=</xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:element>
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a'][2]) and (marc:subfield[@code='d'])">
+<xsl:for-each select="marc:subfield[@code='a']">
+<xsl:value-of select="text()"/>
+<xsl:if test="position()!=last()">
+<xsl:text> ; </xsl:text>
+</xsl:if>
+<xsl:if test="position()=last()">
+<xsl:text>, </xsl:text>
+</xsl:if>
+</xsl:for-each>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='d'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='c'])">
+<xsl:element name="a">
+<xsl:attribute name="href">
+<xsl:text>/cgi-bin/koha/catalogue/search.pl?idx=Publisher&amp;q=</xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:element>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+
+<xsl:when test="(marc:subfield[@code='d'])">
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='e'])">
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='h']">
+<xsl:text> , </xsl:text>
+<xsl:value-of select="marc:subfield[@code='h']"/>
+</xsl:if>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='g'])">
+<xsl:value-of select="marc:subfield[@code='g']"/>
+<xsl:if test="marc:subfield[@code='h']">
+<xsl:text> , </xsl:text>
+<xsl:value-of select="marc:subfield[@code='h']"/>
+</xsl:if>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='h'])">
+<xsl:value-of select="marc:subfield[@code='h']"/>
+</xsl:when>
+</xsl:choose>
+</span>
+</xsl:for-each>
+</xsl:template>
+
+
+<xsl:template name="tag_214">
+<xsl:for-each select="marc:datafield[@tag=214]">
+<span class="results_summary publisher">
+<span class="label">Publication : </span>
+<xsl:choose>
+<xsl:when test="(marc:subfield[@code='a'][2]) and (marc:subfield[@code='c'][2]) and (marc:subfield[@code='d'])">
+<xsl:value-of select="marc:subfield[@code='a'][1]"/>
+<xsl:text> : </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+<xsl:text>/cgi-bin/koha/catalogue/search.pl?idx=Publisher&amp;q=</xsl:text>
+<xsl:value-of select="marc:subfield[@code='c'][1]"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c'][1]"/>
+</xsl:element>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='a'][2]"/>
+<xsl:text> : </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+<xsl:text>/cgi-bin/koha/catalogue/search.pl?idx=Publisher&amp;q=</xsl:text>
+<xsl:value-of select="marc:subfield[@code='c'][2]"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c'][2]"/>
+</xsl:element>
+<xsl:if test="marc:subfield[@code='a'][3]">
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='a'][3]"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='c'][3]">
+<xsl:text> : </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+<xsl:text>/cgi-bin/koha/catalogue/search.pl?idx=Publisher&amp;q=</xsl:text>
+<xsl:value-of select="marc:subfield[@code='c'][3]"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c'][3]"/>
+</xsl:element>
+</xsl:if>
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='c'][2]) and (marc:subfield[@code='d'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:if test="position()!=last()">
+<xsl:text> ; </xsl:text>
+</xsl:if>
+<xsl:if test="position()=last()">
+<xsl:text> : </xsl:text>
+</xsl:if>
+<xsl:for-each select="marc:subfield[@code='c']">
+<xsl:element name="a">
+<xsl:attribute name="href">
+<xsl:text>/cgi-bin/koha/catalogue/search.pl?idx=Publisher&amp;q=</xsl:text>
+<xsl:value-of select="text()"/>
+</xsl:attribute>
+<xsl:value-of select="text()"/>
+</xsl:element>
+<xsl:if test="position()!=last()">
+<xsl:text> : </xsl:text>
+</xsl:if>
+<xsl:if test="position()=last()">
+<xsl:text></xsl:text>
+</xsl:if>
+</xsl:for-each>
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a'][2]) and (marc:subfield[@code='c']) and (marc:subfield[@code='d'])">
+<xsl:for-each select="marc:subfield[@code='a']">
+<xsl:value-of select="text()"/>
+<xsl:if test="position()!=last()">
+<xsl:text> ; </xsl:text>
+</xsl:if>
+<xsl:if test="position()=last()">
+<xsl:text> : </xsl:text>
+</xsl:if>
+</xsl:for-each>
+<xsl:element name="a">
+<xsl:attribute name="href">
+<xsl:text>/cgi-bin/koha/catalogue/search.pl?idx=Publisher&amp;q=</xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:element>
+<xsl:if test="position()!=last()">
+<xsl:text> : </xsl:text>
+</xsl:if>
+<xsl:if test="position()=last()">
+<xsl:text></xsl:text>
+</xsl:if>
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='c']) and (marc:subfield[@code='d'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text> : </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+<xsl:text>/cgi-bin/koha/catalogue/search.pl?idx=Publisher&amp;q=</xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:element>
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='c'][2])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text> : </xsl:text>
+<xsl:for-each select="marc:subfield[@code='c']">
+<xsl:element name="a">
+<xsl:attribute name="href">
+<xsl:text>/cgi-bin/koha/catalogue/search.pl?idx=Publisher&amp;q=</xsl:text>
+<xsl:value-of select="text()"/>
+</xsl:attribute>
+<xsl:value-of select="text()"/>
+</xsl:element>
+<xsl:if test="position()!=last()">
+<xsl:text> : </xsl:text>
+</xsl:if>
+<xsl:if test="position()=last()">
+<xsl:text></xsl:text>
+</xsl:if>
+</xsl:for-each>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='c'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text> : </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+<xsl:text>/cgi-bin/koha/catalogue/search.pl?idx=Publisher&amp;q=</xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:element>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='c'][2]) and (marc:subfield[@code='d'])">
+<xsl:for-each select="marc:subfield[@code='c']">
+<xsl:element name="a">
+<xsl:attribute name="href">
+<xsl:text>/cgi-bin/koha/catalogue/search.pl?idx=Publisher&amp;q=</xsl:text>
+<xsl:value-of select="text()"/>
+</xsl:attribute>
+<xsl:value-of select="text()"/>
+</xsl:element>
+<xsl:if test="position()!=last()">
+<xsl:text> : </xsl:text>
+</xsl:if>
+<xsl:if test="position()=last()">
+<xsl:text>, </xsl:text>
+</xsl:if>
+</xsl:for-each>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='c']) and (marc:subfield[@code='d'])">
+<xsl:element name="a">
+<xsl:attribute name="href">
+<xsl:text>/cgi-bin/koha/catalogue/search.pl?idx=Publisher&amp;q=</xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:element>
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a'][2]) and (marc:subfield[@code='d'])">
+<xsl:for-each select="marc:subfield[@code='a']">
+<xsl:value-of select="text()"/>
+<xsl:if test="position()!=last()">
+<xsl:text> ; </xsl:text>
+</xsl:if>
+<xsl:if test="position()=last()">
+<xsl:text>, </xsl:text>
+</xsl:if>
+</xsl:for-each>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='d'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='c'])">
+<xsl:element name="a">
+<xsl:attribute name="href">
+<xsl:text>/cgi-bin/koha/catalogue/search.pl?idx=Publisher&amp;q=</xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:element>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='d'])">
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='e'])">
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='h']">
+<xsl:text> , </xsl:text>
+<xsl:value-of select="marc:subfield[@code='h']"/>
+</xsl:if>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='g'])">
+<xsl:value-of select="marc:subfield[@code='g']"/>
+<xsl:if test="marc:subfield[@code='h']">
+<xsl:text> , </xsl:text>
+<xsl:value-of select="marc:subfield[@code='h']"/>
+</xsl:if>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='h'])">
+<xsl:value-of select="marc:subfield[@code='h']"/>
+</xsl:when>
+</xsl:choose>
+</span>
+</xsl:for-each>
+</xsl:template>
+
+
+<!--210$s et $r Colophon et adresse transcrite-->
+<xsl:template name="tag_210_s">
+<xsl:if test="marc:datafield[@tag=210]/marc:subfield[@code='s']">
+<span class="results_summary tag_210_s">
+<span class="label">Colophon : </span>
+<xsl:for-each select="marc:datafield[@tag=210]">
+<xsl:value-of select="marc:subfield[@code='s']"/>
+<xsl:choose>
+<xsl:when test="position()=last()">
+<xsl:text>.</xsl:text>
+</xsl:when>
+<xsl:otherwise><xsl:text>, </xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:for-each>
+</span>
+</xsl:if>
+</xsl:template>
+
+<xsl:template name="tag_210_r">
+<xsl:if test="marc:datafield[@tag=210]/marc:subfield[@code='r']">
+<span class="results_summary tag_210_r">
+<span class="label">Adresse transcrite : </span>
+<xsl:for-each select="marc:datafield[@tag=210]">
+<xsl:value-of select="marc:subfield[@code='r']"/>
+<xsl:choose>
+<xsl:when test="position()=last()">
+<xsl:text>.</xsl:text>
+</xsl:when>
+<xsl:otherwise><xsl:text>, </xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:for-each>
+</span>
+</xsl:if>
+</xsl:template>
+
+<!--TB-214$s et $r Colophon et adresse transcrite-->
+<xsl:template name="tag_214_s">
+<xsl:if test="marc:datafield[@tag=214]/marc:subfield[@code='s']">
+<span class="results_summary tag_214_s">
+<span class="label">Colophon : </span>
+<xsl:for-each select="marc:datafield[@tag=214]">
+<xsl:value-of select="marc:subfield[@code='s']"/>
+<xsl:choose>
+<xsl:when test="position()=last()">
+<xsl:text>.</xsl:text>
+</xsl:when>
+<xsl:otherwise><xsl:text>, </xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:for-each>
+</span>
+</xsl:if>
+</xsl:template>
+
+<xsl:template name="tag_214_r">
+<xsl:if test="marc:datafield[@tag=214]/marc:subfield[@code='r']">
+<span class="results_summary tag_214_r">
+<span class="label">Adresse transcrite : </span>
+<xsl:for-each select="marc:datafield[@tag=214]">
+<xsl:value-of select="marc:subfield[@code='r']"/>
+<xsl:choose>
+<xsl:when test="position()=last()">
+<xsl:text>.</xsl:text>
+</xsl:when>
+<xsl:otherwise><xsl:text>, </xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:for-each>
+</span>
+</xsl:if>
+</xsl:template>
+
+<xsl:template name="tag_215">
+<xsl:for-each select="marc:datafield[@tag=215]">
+<span class="results_summary description">
+<span class="label">Description : </span>
+<xsl:choose>
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='c']) and (marc:subfield[@code='d']) and (marc:subfield[@code='e'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:text> + </xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='c']) and (marc:subfield[@code='d'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='e']) and (marc:subfield[@code='d'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:text> + </xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='e']) and (marc:subfield[@code='c'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+<xsl:text> + </xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='c'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='d'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='e'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text> + </xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='a'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='c'])">
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='d'])">
+<xsl:value-of select="marc:subfield[@code='d']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='e'])">
+<xsl:value-of select="marc:subfield[@code='e']"/>
+</xsl:when>
+</xsl:choose>
+</span>
+</xsl:for-each>
+</xsl:template>
+
+<!--Titre de serie autorité 461-->
+<xsl:template name="tag_461">
+<xsl:for-each select="marc:datafield[@tag=461]">
+<span class="results_summary tag_461">
+<span class="label">Titre de série : </span>
+<xsl:call-template name="addClassRtl" />
+<xsl:choose>
+<xsl:when test="marc:subfield[@code='9']">
+<xsl:element name="a"><xsl:attribute name="href">
+/cgi-bin/koha/catalogue/search.pl?q=an:<xsl:value-of select="marc:subfield[@code='9']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='t']"/></xsl:element>
+</xsl:when>
+<xsl:otherwise>
+<xsl:element name="a"><xsl:attribute name="href">
+/cgi-bin/koha/catalogue/search.pl?idx=index-title-serie,phr&amp;q=<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='t']"/></xsl:element>
+</xsl:otherwise>
+</xsl:choose>
+<xsl:if test="marc:subfield[@code='e']"> :
+<xsl:value-of select="marc:subfield[@code='e']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='f']"> /
+<xsl:value-of select="marc:subfield[@code='f']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='d']"> ,
+<xsl:value-of select="marc:subfield[@code='d']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='p']"> ,
+<xsl:value-of select="marc:subfield[@code='p']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='v']">,
+<xsl:value-of select="marc:subfield[@code='v']"/>
+</xsl:if>
+</span>
+</xsl:for-each>
+</xsl:template>
+
+<!--Titre de serie non autorité 461-->
+<xsl:template name="tag_461bis">
+<xsl:variable name="type_doc" select="marc:datafield[@tag=099]/marc:subfield[@code='t']"/>
+<xsl:for-each select="marc:datafield[@tag=461]">
+<xsl:call-template name="addClassRtl" />
+<xsl:choose>
+<!--si notice d'article-->
+<xsl:when test="contains($type_doc,'Article') and marc:subfield[@code='9']">
+<li style="list-style-type: none;">
+<strong>Titre du périodique : </strong>
+<xsl:if test="marc:subfield[@code='a']">
+<xsl:value-of select="marc:subfield[@code='a']"/><xsl:text> , </xsl:text>
+</xsl:if>
+<xsl:element name="a"><xsl:attribute name="href">
+/cgi-bin/koha/catalogue/search.pl?idx=sn&amp;q=<xsl:value-of select="marc:subfield[@code='9']
+"/>
+</xsl:attribute> <xsl:value-of select="marc:subfield[@code='t']"/></xsl:element>
+<xsl:element name="a"><xsl:attribute name="href">
+/cgi-bin/koha/catalogue/search.pl?idx=index-title-serie,phr&amp;q=<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:attribute> - Voir les autres articles</xsl:element>
+</li>
+</xsl:when>
+<!--sinon-->
+<xsl:otherwise>
+<li style="list-style-type: none;">
+<strong>Titre de la série : </strong>
+<xsl:if test="marc:subfield[@code='a']">
+<xsl:value-of select="marc:subfield[@code='a']"/><xsl:text> , </xsl:text>
+</xsl:if>
+<xsl:element name="a"><xsl:attribute name="href">
+/cgi-bin/koha/catalogue/search.pl?idx=index-title-serie,phr&amp;q=<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:attribute> <xsl:value-of select="marc:subfield[@code='t']"/></xsl:element>
+</li>
+</xsl:otherwise>
+</xsl:choose>
+<xsl:if test="marc:datafield[@tag=461]/marc:subfield[@code='e']"> :
+<xsl:value-of select="marc:datafield[@tag=461]/marc:subfield[@code='e']"/>
+</xsl:if>
+<xsl:if test="marc:datafield[@tag=461]/marc:subfield[@code='f']"> /
+<xsl:value-of select="marc:datafield[@tag=461]/marc:subfield[@code='f']"/>
+</xsl:if>
+<xsl:if test="marc:datafield[@tag=461]/marc:subfield[@code='d']"> ,
+<xsl:value-of select="marc:datafield[@tag=461]/marc:subfield[@code='d']"/>
+</xsl:if>
+<xsl:if test="marc:datafield[@tag=461]/marc:subfield[@code='p']"> ,
+<xsl:value-of select="marc:datafield[@tag=461]/marc:subfield[@code='p']"/>
+</xsl:if>
+<xsl:if test="marc:datafield[@tag=461]/marc:subfield[@code='v']">,
+<xsl:value-of select="marc:datafield[@tag=461]/marc:subfield[@code='v']"/>
+</xsl:if>
+<xsl:if test="marc:datafield[@tag=461]/marc:subfield[@code='w']"> -
+<xsl:value-of select="marc:datafield[@tag=461]/marc:subfield[@code='w']"/>
+</xsl:if>
+</xsl:for-each>	
+</xsl:template>
+<!--Titre dépouillé 463-->
+<xsl:template name="tag_463">
+<xsl:for-each select="marc:datafield[@tag=463][1]">
+<span class="results_summary tag_463">
+<span class="label">Titre dépouillé : </span>
+<xsl:call-template name="addClassRtl" />
+<xsl:if test="marc:subfield[@code='a']">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+</xsl:if>
+<xsl:choose>
+<xsl:when test="marc:subfield[@code='9']">
+<xsl:element name="a"><xsl:attribute name="href">
+/cgi-bin/koha/catalogue/search.pl?idx=Local-number,phr&amp;q=<xsl:value-of select="marc:subfield[@code='9']"/>
+</xsl:attribute> <xsl:value-of select="marc:subfield[@code='t']"/></xsl:element>
+</xsl:when>
+<xsl:otherwise>
+<xsl:element name="a"><xsl:attribute name="href">
+/cgi-bin/koha/catalogue/search.pl?idx=index-title-article,phr&amp;q=<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:attribute> <xsl:value-of select="marc:subfield[@code='t']"/></xsl:element>
+</xsl:otherwise>
+</xsl:choose>
+<xsl:if test="marc:subfield[@code='e']"> :
+<xsl:value-of select="marc:subfield[@code='e']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='f']"> /
+<xsl:value-of select="marc:subfield[@code='f']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='d']"> ,
+<xsl:value-of select="marc:subfield[@code='d']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='p']"> ,
+<xsl:value-of select="marc:subfield[@code='p']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='v']">,
+<xsl:value-of select="marc:subfield[@code='v']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='w']"> -
+<xsl:value-of select="marc:subfield[@code='w']"/>
+</xsl:if>
+</span>
+</xsl:for-each>
+</xsl:template>
+
+<xsl:template name="tag_4xx">
+<xsl:param name="tag" />
+<xsl:param name="label" />
+<xsl:if test="marc:datafield[@tag=$tag]">
+<span class="results_summary tag_4xx">
+<span class="label"><xsl:value-of select="$label" /> : </span>
+<xsl:for-each select="marc:datafield[@tag=$tag]">
+<span>
+<xsl:call-template name="addClassRtl" />
+<xsl:choose>
+<xsl:when test="marc:subfield[@code='9']">
+<xsl:element name="a"><xsl:attribute name="href">
+/cgi-bin/koha/catalogue/search.pl?idx=Local-number,phr&amp;q=<xsl:value-of select="marc:subfield[@code='9']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='t']"/></xsl:element>
+</xsl:when>
+<xsl:when test="marc:subfield[@code='0']">
+<xsl:element name="a"><xsl:attribute name="href">
+/cgi-bin/koha/catalogue/search.pl?idx=kw,phr&amp;q=<xsl:value-of select="marc:subfield[@code='0']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='t']"/></xsl:element>
+</xsl:when>
+<xsl:otherwise>
+<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:otherwise>
+</xsl:choose>
+<xsl:if test="marc:subfield[@code='c']"> : <xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='d']"> ; <xsl:value-of select="marc:subfield[@code='d']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='e'][1]"> - <xsl:value-of select="marc:subfield[@code='e'][1]"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='f'][1]"> - <xsl:value-of select="marc:subfield[@code='f'][1]"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='g'][1]"> - <xsl:value-of select="marc:subfield[@code='g'][1]"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='h'][1]"> - <xsl:value-of select="marc:subfield[@code='h'][1]"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='i'][1]"> - <xsl:value-of select="marc:subfield[@code='i'][1]"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='l'][1]"> - <xsl:value-of select="marc:subfield[@code='l'][1]"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='v'][1]"> , <xsl:value-of select="marc:subfield[@code='v'][1]"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='x']">,
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/catalogue/search.pl?idx=ns&amp;q=<xsl:value-of select="marc:subfield[@code='x'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='y']">,
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/catalogue/search.pl?idx=nb&amp;q=<xsl:value-of select="marc:subfield[@code='y'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='y'][1]"/></xsl:element>
+</xsl:if>
+</span>
+<xsl:if test="not (position() = last())">
+<xsl:text> ; </xsl:text>
+</xsl:if>
+</xsl:for-each>
+</span>
+</xsl:if>
+</xsl:template>
+
+<xsl:template name="tag_462_ppn">
+<xsl:variable name="ppn" select="marc:controlfield[@tag=009]"/>
+<xsl:for-each select="marc:controlfield[@tag=009]">
+<span class="results_summary tag_462">
+<span class="label">Liste des unités dépouillées : </span>
+<span>
+<xsl:call-template name="addClassRtl" />
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/catalogue/search.pl?idx=kw,phr&amp;q=<xsl:value-of select="$ppn"/>
+</xsl:attribute>Voir titres</xsl:element>
+</span>
+</span>
+</xsl:for-each>
+</xsl:template>
+
+<xsl:template name="tag_462">
+<xsl:for-each select="marc:datafield[@tag=090][1]">
+<span class="results_summary tag_462">
+<span class="label">Liste des unités dépouillées : </span>
+<span>
+<xsl:call-template name="addClassRtl" />
+<xsl:if test="marc:subfield[@code='a']">
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/catalogue/search.pl?idx=index-lien-desc,phr&amp;q=<xsl:value-of select="marc:subfield[@code='a'][1]"/>
+</xsl:attribute>Voir titres</xsl:element>
+</xsl:if>
+</span>
+</span>
+</xsl:for-each>
+</xsl:template>
+
+
+<!--Public 995q-->
+<xsl:template name="public">
+<xsl:if test="marc:datafield[@tag=995]/marc:subfield[@code='q']">
+<span class="results_summary public">
+<span class="label">Public : </span>
+<xsl:for-each select="marc:datafield[@tag=995]/marc:subfield[@code='q']">
+<xsl:if test="position() = 1">
+<xsl:value-of select="." />
+</xsl:if>
+</xsl:for-each>
+</span>
+</xsl:if>
+</xsl:template>
+
+<!--Fonds 995h-->
+<xsl:template name="fonds">
+<xsl:if test="marc:datafield[@tag=995]/marc:subfield[@code='h']">
+<span class="results_summary founds">
+<span class="label">Fonds : </span>
+<xsl:for-each select="marc:datafield[@tag=995]/marc:subfield[@code='h']">
+<xsl:if test="position() = 1">
+<xsl:value-of select="." />
+</xsl:if></xsl:for-each>
+</span>
+</xsl:if>
+</xsl:template>
+
+<xsl:template name="subfieldSelect">
+<xsl:param name="codes"/>
+<xsl:param name="delimeter"><xsl:text> </xsl:text></xsl:param>
+<xsl:param name="subdivCodes"/>
+<xsl:param name="subdivDelimiter"/>
+<xsl:variable name="str">
+<xsl:for-each select="marc:subfield">
+<xsl:if test="contains($codes, @code)">
+<xsl:if test="contains($subdivCodes, @code)">
+<xsl:value-of select="$subdivDelimiter"/>
+</xsl:if>
+<xsl:value-of select="text()"/><xsl:value-of select="$delimeter"/>
+</xsl:if>
+</xsl:for-each>
+</xsl:variable>
+<xsl:value-of select="substring($str,1,string-length($str)-string-length($delimeter))"/>
+</xsl:template>
+
+<xsl:template name="buildSpaces">
+<xsl:param name="spaces"/>
+<xsl:param name="char"><xsl:text> </xsl:text></xsl:param>
+<xsl:if test="$spaces>0">
+<xsl:value-of select="$char"/>
+<xsl:call-template name="buildSpaces">
+<xsl:with-param name="spaces" select="$spaces - 1"/>
+<xsl:with-param name="char" select="$char"/>
+</xsl:call-template>
+</xsl:if>
+</xsl:template>
+
+<xsl:template name="buildBiblioDefaultViewURL">
+<xsl:param name="IntranetBiblioDefaultView"/>
+<xsl:choose>
+<xsl:when test="$IntranetBiblioDefaultView='normal'">
+<xsl:text>/cgi-bin/koha/catalogue/detail.pl?biblionumber=</xsl:text>
+</xsl:when>
+<xsl:when test="$IntranetBiblioDefaultView='isbd'">
+<xsl:text>/cgi-bin/koha/catalogue/detail.pl?biblionumber=</xsl:text>
+</xsl:when>
+<xsl:when test="$IntranetBiblioDefaultView='labeled_marc'">
+<xsl:text>/cgi-bin/koha/catalogue/detail.pl?biblionumber=</xsl:text>
+</xsl:when>
+<xsl:when test="$IntranetBiblioDefaultView='marc'">
+<xsl:text>/cgi-bin/koha/catalogue/detail.pl?biblionumber=</xsl:text>
+</xsl:when>
+<xsl:otherwise>
+<xsl:text>/cgi-bin/koha/catalogue/detail.pl?biblionumber=</xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:template>
+
+<xsl:template name="chopSpecialCharacters">
+<xsl:param name="title" />
+<xsl:variable name="ntitle"
+select="translate($title, '&#x0098;&#x009C;&#xC29C;&#xC29B;&#xC298;&#xC288;&#xC289;','')"/>
+<xsl:value-of select="$ntitle" />
+</xsl:template>
+
+<xsl:template name="chopPunctuation">
+<xsl:param name="chopString"/>
+<xsl:variable name="length" select="string-length($chopString)"/>
+<xsl:choose>
+<xsl:when test="$length=0"/>
+<xsl:when test="contains('.:,;/ ', substring($chopString,$length,1))">
+<xsl:call-template name="chopPunctuation">
+<xsl:with-param name="chopString" select="substring($chopString,1,$length - 1)"/>
+</xsl:call-template>
+</xsl:when>
+<xsl:when test="not($chopString)"/>
+<xsl:otherwise><xsl:value-of select="$chopString"/></xsl:otherwise>
+</xsl:choose>
+<xsl:text> </xsl:text>
+</xsl:template>
+
+<xsl:template name="addClassRtl">
+<xsl:variable name="lang" select="marc:subfield[@code='7']" />
+<xsl:if test="$lang = 'ha' or $lang = 'Hebrew' or $lang = 'fa' or $lang = 'Arabe'">
+<xsl:attribute name="class">rtl</xsl:attribute>
+</xsl:if>
+</xsl:template>
+
+
+ <xsl:template name="tag_title_collection">
+ <xsl:param name="tag" />
+ <xsl:param name="label" />
+ <xsl:param name="spanclass" />
+ <xsl:if test="marc:datafield[@tag=$tag]">
+ <span class="results_summary {$spanclass}">
+ <span class="label"><xsl:value-of select="$label"/> : </span>
+ <xsl:for-each select="marc:datafield[@tag=$tag]">
+ <xsl:call-template name="addClassRtl" />
+ <xsl:for-each select="marc:subfield">
+ <xsl:choose>
+ <xsl:when test="@code='a'">
+ <xsl:variable name="title" select="."/>
+ <xsl:variable name="ntitle" select="translate($title, '&#x0088;&#x0089;&#x0098;&#x009C;','')"/>
+ <xsl:value-of select="$ntitle" />
+ </xsl:when>
+ <xsl:when test="@code='b'">
+ <xsl:text>[</xsl:text>
+ <xsl:value-of select="."/>
+ <xsl:text>]</xsl:text>
+ </xsl:when>
+ <xsl:when test="@code='d'">
+ <xsl:text> = </xsl:text>
+ <xsl:value-of select="."/>
+ </xsl:when>
+ <xsl:when test="@code='e'">
+ <xsl:text> : </xsl:text>
+ <xsl:value-of select="."/>
+ </xsl:when>
+ <xsl:when test="@code='f'">
+ <xsl:text> / </xsl:text>
+ <xsl:value-of select="."/>
+ </xsl:when>
+ <xsl:when test="@code='g'">
+ <xsl:text> ; </xsl:text>
+ <xsl:value-of select="."/>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:if test="position()>1">
+ <xsl:text>, </xsl:text>
+ </xsl:if>
+ <xsl:value-of select="."/>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+ <xsl:if test="not (position() = last())">
+ <xsl:text>. -</xsl:text>
+ </xsl:if>
+ </xsl:for-each>
+ </span>
+ </xsl:if>
+ </xsl:template>
+
+
+<xsl:template name="tag_title">
+<xsl:param name="tag" />
+<xsl:param name="label" />
+<xsl:param name="spanclass" />
+<xsl:if test="marc:datafield[@tag=$tag]">
+<span class="results_summary titles {$spanclass}">
+<span class="label"><xsl:value-of select="$label"/> : </span>
+<xsl:for-each select="marc:datafield[@tag=$tag]">
+<xsl:value-of select="marc:subfield[@code='a']" />
+<xsl:if test="marc:subfield[@code='d']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:for-each select="marc:subfield[@code='e']">
+<xsl:text> </xsl:text>
+<xsl:value-of select="."/>
+</xsl:for-each>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='f']">
+<xsl:text> / </xsl:text>
+<xsl:value-of select="marc:subfield[@code='f']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='h']">
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='h']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='i']">
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='i']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='v']">
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='v']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='x']">
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='x']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='z']">
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='z']"/>
+</xsl:if>
+</xsl:for-each>
+</span>
+</xsl:if>
+</xsl:template>
+
+
+<xsl:template name="tag_subject">
+<xsl:param name="tag" />
+<xsl:param name="label" />
+<xsl:param name="spanclass" />
+<xsl:if test="marc:datafield[@tag=$tag]">
+<span class="results_summary subjects {$spanclass}">
+<span class="label"><xsl:value-of select="$label"/> : </span>
+<xsl:for-each select="marc:datafield[@tag=$tag]">
+<a>
+<xsl:choose>
+<xsl:when test="marc:subfield[@code=9]">
+<xsl:attribute name="href">/cgi-bin/koha/catalogue/search.pl?q=an:<xsl:value-of select="marc:subfield[@code=9]"/></xsl:attribute>
+</xsl:when>
+<xsl:otherwise>
+<xsl:attribute name="href">/cgi-bin/koha/catalogue/search.pl?q=su:<xsl:value-of select="marc:subfield[@code='a']"/></xsl:attribute>
+</xsl:otherwise>
+</xsl:choose>
+<xsl:call-template name="chopPunctuation">
+<xsl:with-param name="chopString">
+<xsl:call-template name="subfieldSelect">
+<xsl:with-param name="codes">abcdjpvxyz</xsl:with-param>
+<xsl:with-param name="subdivCodes">jpxyz</xsl:with-param>
+<xsl:with-param name="subdivDelimiter">-- </xsl:with-param>
+</xsl:call-template>
+</xsl:with-param>
+</xsl:call-template>
+</a>
+<xsl:if test="not (position()=last())">
+<xsl:text> | </xsl:text>
+</xsl:if>
+</xsl:for-each>
+</span>
+</xsl:if>
+</xsl:template>
+
+<xsl:template name="tag_71x">
+ <xsl:param name="tag" />
+ <xsl:param name="label" />
+ <xsl:param name="spanclass" />
+ <xsl:if test="marc:datafield[@tag=$tag]">
+ <span class="results_summary author {$spanclass}">
+ <span class="label">
+ <xsl:value-of select="$label" />
+ <xsl:text> : </xsl:text>
+ </span>
+ <xsl:for-each select="marc:datafield[@tag=$tag]">
+ <span>
+ <xsl:call-template name="addClassRtl" />
+ <a>
+ <xsl:choose>
+ <xsl:when test="marc:subfield[@code=9]">
+ <xsl:attribute name="href">/cgi-bin/koha/catalogue/search.pl?q=an:<xsl:value-of select="marc:subfield[@code=9]"/></xsl:attribute>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:attribute name="href">/cgi-bin/koha/catalogue/search.pl?q=au:<xsl:value-of select="marc:subfield[@code='a']"/><xsl:text> </xsl:text><xsl:value-of select="marc:subfield[@code='b']"/></xsl:attribute>
+ </xsl:otherwise>
+ </xsl:choose>
+ <xsl:if test="marc:subfield[@code='a']">
+ <xsl:value-of select="marc:subfield[@code='a']"/>
+ </xsl:if>
+ <xsl:if test="marc:subfield[@code='b']">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='b']"/>
+ </xsl:if>
+ <xsl:if test="marc:subfield[@code='b'][2]">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='b'][2]"/>
+ </xsl:if>
+ <xsl:if test="marc:subfield[@code='b'][3]">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='b'][3]"/>
+ </xsl:if>
+ <xsl:if test="marc:subfield[@code='c']">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='c']"/>
+ </xsl:if>
+<xsl:choose>
+<xsl:when test="(marc:subfield[@code='d']) and (marc:subfield[@code='f']) and (marc:subfield[@code='e'])">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:text> ; </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='f']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='d']) and (marc:subfield[@code='f'])">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:text> ; </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='f']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='d']) and (marc:subfield[@code='e'])">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:text> ; </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='e']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='e']) and (marc:subfield[@code='f'])">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:text> ; </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='f']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+<xsl:when test="marc:subfield[@code='d']">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+<xsl:when test="marc:subfield[@code='e']">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='e']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+<xsl:when test="marc:subfield[@code='f']">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='f']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+</xsl:choose>
+<xsl:if test="marc:subfield[@code='4']">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='4']"/>
+<xsl:text> ) </xsl:text>
+ </xsl:if>
+ </a>
+ </span>
+ <xsl:if test="not (position() = last())">
+ <xsl:text> ; </xsl:text>
+ </xsl:if>
+ </xsl:for-each>
+ </span>
+ </xsl:if>
+ </xsl:template>
+
+
+<xsl:template name="tag_7xx">
+<xsl:param name="tag" />
+<xsl:param name="label" />
+<xsl:param name="spanclass" />
+<xsl:if test="marc:datafield[@tag=$tag]">
+<span class="results_summary author {$spanclass}">
+<span class="label">
+<xsl:value-of select="$label" />
+<xsl:text> : </xsl:text>
+</span>
+<xsl:for-each select="marc:datafield[@tag=$tag]">
+<span>
+<xsl:call-template name="addClassRtl" />
+<a>
+<xsl:choose>
+<xsl:when test="marc:subfield[@code=9]">
+<xsl:attribute name="href">/cgi-bin/koha/catalogue/search.pl?q=an:<xsl:value-of select="marc:subfield[@code=9]"/></xsl:attribute>
+</xsl:when>
+<xsl:otherwise>
+<xsl:attribute name="href">/cgi-bin/koha/catalogue/search.pl?q=au:<xsl:value-of select="marc:subfield[@code='a']"/><xsl:text> </xsl:text><xsl:value-of select="marc:subfield[@code='b']"/></xsl:attribute>
+</xsl:otherwise>
+</xsl:choose>
+<xsl:if test="marc:subfield[@code='a']">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='b']">
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='b']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='c']">
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='d']">
+<xsl:text> </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='f']">
+<span dir="ltr">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='f']"/>
+<xsl:text>)</xsl:text>
+</span>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='p']">
+<xsl:text> </xsl:text>
+<xsl:value-of select="marc:subfield[@code='p']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='4']">
+<xsl:text> ( </xsl:text>
+<xsl:value-of select="marc:subfield[@code='4']"/>
+<xsl:text> ) </xsl:text>
+</xsl:if>
+</a>
+</span>
+<xsl:if test="not (position() = last())">
+<xsl:text> ; </xsl:text>
+</xsl:if>
+</xsl:for-each>
+</span>
+</xsl:if>
+</xsl:template>
+
+<xsl:template name="RCR">
+  <xsl:param name="code"/>
+  <xsl:choose>
+    <xsl:when test="$code='xxxxxxxxx'">Bibliothèque xxxxxxxxx</xsl:when>
+    <xsl:when test="$code='yyyyyyyyy'">Bibliothèque yyyyyyyyy</xsl:when>
+    <xsl:otherwise><xsl:value-of select="$code"/></xsl:otherwise>
+  </xsl:choose>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/biblibre/opac/en/UNIMARCslim2OPACDetail.xsl
+++ b/biblibre/opac/en/UNIMARCslim2OPACDetail.xsl
@@ -1,0 +1,2923 @@
+<xsl:stylesheet version="1.0"
+  xmlns:marc="http://www.loc.gov/MARC21/slim"
+  xmlns:items="http://www.koha-community.org/items"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  exclude-result-prefixes="marc items">
+
+<xsl:import href="UNIMARCslimUtils.xsl"/>
+<xsl:output method = "html" indent="yes" omit-xml-declaration = "yes" encoding="UTF-8"/>
+<xsl:template match="/">
+<xsl:apply-templates/>
+</xsl:template>
+
+<xsl:template match="marc:record">
+<xsl:variable name="Show856uAsImage" select="marc:sysprefs/marc:syspref[@name='Display856uAsImage']"/>
+<xsl:variable name="leader" select="marc:leader"/>
+<xsl:variable name="leader6" select="substring($leader,7,1)"/>
+<xsl:variable name="leader7" select="substring($leader,8,1)"/>
+<xsl:variable name="biblionumber" select="marc:controlfield[@tag=001]"/>
+<xsl:variable name="ppn" select="marc:controlfield[@tag=009]"/>
+<xsl:variable name="coverCD" select="marc:datafield[@tag=933]/marc:subfield[@code='a']"/>
+<xsl:variable name="type_doc" select="marc:datafield[@tag=099]/marc:subfield[@code='t']"/>
+
+<!--<xsl:if test="$coverCD!=' '">
+<div id='jacquette'>
+<xsl:if test="marc:datafield[@tag=933]">
+<xsl:for-each select="marc:datafield[@tag=933]">
+<img class="coverimages" height="80" width="80"><xsl:attribute name="src"><xsl:value-of select="marc:subfield[@code='a']"/></xsl:attribute></img>
+<xsl:choose>
+<xsl:when test="position()=last()"/>
+</xsl:choose>
+</xsl:for-each>
+</xsl:if> </div></xsl:if>
+-->
+
+<xsl:if test="marc:datafield[@tag=200]">
+<xsl:for-each select="marc:datafield[@tag=200]">
+<h1>
+<xsl:call-template name="addClassRtl" />
+<xsl:variable name="title" select="marc:subfield[@code='a']"/>
+<xsl:variable name="ntitle"
+select="translate($title, '&#x0098;&#x009C;&#xC29C;&#xC29B;&#xC298;&#xC288;&#xC289;','')"/>
+<!--<xsl:value-of select="$ntitle" />-->
+<xsl:value-of select="marc:subfield[@code='a'][1]" />
+<xsl:if test="marc:subfield[@code='e'][1]"><xsl:text> : </xsl:text><xsl:value-of select="marc:subfield[@code='e'][1]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='c'][1]"><xsl:text> . </xsl:text><xsl:value-of select="marc:subfield[@code='c'][1]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='d'][1]"><xsl:text> = </xsl:text><xsl:value-of select="marc:subfield[@code='d'][1]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='v'][1]"><xsl:text> . </xsl:text><xsl:value-of select="marc:subfield[@code='v'][1]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='h'][1]"><xsl:text> . </xsl:text><xsl:value-of select="marc:subfield[@code='h'][1]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='i'][1]"><xsl:text> . </xsl:text><xsl:value-of select="marc:subfield[@code='i'][1]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='e'][2]"><xsl:text> : </xsl:text><xsl:value-of select="marc:subfield[@code='e'][2]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='c'][2]"><xsl:text> . </xsl:text><xsl:value-of select="marc:subfield[@code='c'][1]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='d'][2]"><xsl:text> = </xsl:text><xsl:value-of select="marc:subfield[@code='d'][2]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='h'][2]"><xsl:text> . </xsl:text><xsl:value-of select="marc:subfield[@code='h'][2]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='i'][2]"><xsl:text> . </xsl:text><xsl:value-of select="marc:subfield[@code='i'][2]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='e'][3]"><xsl:text> : </xsl:text><xsl:value-of select="marc:subfield[@code='e'][3]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='c'][3]"><xsl:text> . </xsl:text><xsl:value-of select="marc:subfield[@code='c'][3]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='d'][3]"><xsl:text> = </xsl:text><xsl:value-of select="marc:subfield[@code='d'][3]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='h'][3]"><xsl:text> . </xsl:text><xsl:value-of select="marc:subfield[@code='h'][3]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='i'][3]"><xsl:text> . </xsl:text><xsl:value-of select="marc:subfield[@code='i'][3]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='a'][2]"><xsl:text>. </xsl:text><xsl:value-of select="marc:subfield[@code='a'][2]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='a'][3]"><xsl:text>. </xsl:text><xsl:value-of select="marc:subfield[@code='a'][3]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='b']"><xsl:text> [</xsl:text><xsl:value-of select="marc:subfield[@code='b']"/><xsl:text>] </xsl:text>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='f']">
+<xsl:text> / </xsl:text>
+<xsl:if test="marc:subfield[@code='f'][1]"><xsl:text></xsl:text><xsl:value-of select="marc:subfield[@code='f'][1]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='f'][2]"><xsl:text> ; </xsl:text><xsl:value-of select="marc:subfield[@code='f'][2]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='f'][3]"><xsl:text> ; </xsl:text><xsl:value-of select="marc:subfield[@code='f'][3]" /></xsl:if>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='g'][1]"><xsl:text> ; </xsl:text><xsl:value-of select="marc:subfield[@code='g'][1]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='g'][2]"><xsl:text> ; </xsl:text><xsl:value-of select="marc:subfield[@code='g'][2]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='g'][3]"><xsl:text> ; </xsl:text><xsl:value-of select="marc:subfield[@code='g'][3]" /></xsl:if>
+</h1>
+</xsl:for-each>
+</xsl:if>
+
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">412</xsl:with-param>
+<xsl:with-param name="label">Is an excerpt or taken apart from</xsl:with-param>
+</xsl:call-template>
+
+<xsl:for-each select="marc:datafield[@tag=413]">
+<span class="results_summary">
+<span class="label">A for extract or pulled apart : </span>
+<xsl:choose>
+<xsl:when test="(marc:subfield[@code='t']) and (marc:subfield[@code='o']) and  (marc:subfield[@code='f']) and (marc:subfield[@code='c']) and (marc:subfield[@code='n']) and (marc:subfield[@code='d'])">
+ <xsl:value-of select="marc:subfield[@code='t']"/>
+<xsl:text> : </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='o']"/>
+<xsl:text> / </xsl:text>
+<xsl:value-of select="marc:subfield[@code='f']"/>
+ <xsl:text>. - </xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+ <xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='n']"/>
+ <xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='t']) and (marc:subfield[@code='o']) and (marc:subfield[@code='c']) and (marc:subfield[@code='n']) and (marc:subfield[@code='d'])">
+ <xsl:value-of select="marc:subfield[@code='t']"/>
+<xsl:text> : </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='o']"/>
+ <xsl:text>. - </xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+ <xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='n']"/>
+ <xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='t']) and (marc:subfield[@code='f']) and (marc:subfield[@code='c']) and (marc:subfield[@code='n']) and (marc:subfield[@code='d'])">
+ <xsl:value-of select="marc:subfield[@code='t']"/>
+<xsl:text> / </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='f']"/>
+ <xsl:text>. - </xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+ <xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='n']"/>
+ <xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='t']) and (marc:subfield[@code='c']) and (marc:subfield[@code='n']) and (marc:subfield[@code='d'])">
+ <xsl:value-of select="marc:subfield[@code='t']"/>
+ <xsl:text>. - </xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+ <xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='n']"/>
+ <xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+</xsl:when>
+<xsl:when test="marc:subfield[@code='t']">
+ <xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:when>
+</xsl:choose>
+ </span>
+ </xsl:for-each>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">421</xsl:with-param>
+<xsl:with-param name="label">Has for supplement</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">422</xsl:with-param>
+<xsl:with-param name="label">Is a supplement of</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">423</xsl:with-param>
+<xsl:with-param name="label">Is published with</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">424</xsl:with-param>
+<xsl:with-param name="label">Is updated by</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">430</xsl:with-param>
+<xsl:with-param name="label">Following</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">431</xsl:with-param>
+<xsl:with-param name="label">Succeeds after division of</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">432</xsl:with-param>
+<xsl:with-param name="label">Replace</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">433</xsl:with-param>
+<xsl:with-param name="label">Replace partially</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">434</xsl:with-param>
+<xsl:with-param name="label">Absorbed</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">435</xsl:with-param>
+<xsl:with-param name="label">Absorbed partially</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">436</xsl:with-param>
+<xsl:with-param name="label">Merge of</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">437</xsl:with-param>
+<xsl:with-param name="label">Partial sequence of</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">440</xsl:with-param>
+<xsl:with-param name="label">Becomes</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">441</xsl:with-param>
+<xsl:with-param name="label">Become partially</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">442</xsl:with-param>
+<xsl:with-param name="label">Replace by</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">443</xsl:with-param>
+<xsl:with-param name="label">Replace partially by</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">444</xsl:with-param>
+<xsl:with-param name="label">Absorbed by</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">447</xsl:with-param>
+<xsl:with-param name="label">Merged with...to train</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">451</xsl:with-param>
+<xsl:with-param name="label">Other edition, same support</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">452</xsl:with-param>
+<xsl:with-param name="label">Other edition, different support</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">453</xsl:with-param>
+<xsl:with-param name="label">Translated under the title</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">454</xsl:with-param>
+<xsl:with-param name="label">Is a translation of</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">455</xsl:with-param>
+<xsl:with-param name="label">Is a reproduction of</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">456</xsl:with-param>
+<xsl:with-param name="label">Is reproducted as</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">464</xsl:with-param>
+<xsl:with-param name="label">Component</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">470</xsl:with-param>
+<xsl:with-param name="label">Analysed document</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">481</xsl:with-param>
+<xsl:with-param name="label">Is also linked in this volume</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">482</xsl:with-param>
+<xsl:with-param name="label">Linked as a result of</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">488</xsl:with-param>
+<xsl:with-param name="label">Other type of relation</xsl:with-param>
+</xsl:call-template>
+
+<xsl:if test="contains($type_doc,'Périodique')">
+<xsl:call-template name="tag_462" />
+<xsl:choose>
+<xsl:when test="$ppn">
+<xsl:call-template name="tag_462_ppn" />
+</xsl:when>
+<xsl:otherwise>
+<xsl:call-template name="tag_462" />
+</xsl:otherwise>
+</xsl:choose>
+</xsl:if>
+
+<!--Titre de serie autorite 461-->
+<!--<xsl:call-template name="tag_461" />-->
+
+<!---Titre de serie non autorite 461-->
+<xsl:call-template name="tag_461bis" />
+
+<!--Titre dépouillé 463-->
+<xsl:call-template name="tag_463" />
+
+
+<xsl:if test="marc:datafield[@tag=531]"> 
+<span class="results_summary">
+<span class="label">Short title : </span>
+<xsl:for-each select="marc:datafield[@tag=531]">
+<xsl:for-each select="marc:subfield">
+<xsl:value-of select="text()"/>
+<xsl:choose>
+<xsl:when test="position()=last()">
+<xsl:text>.</xsl:text>
+</xsl:when>
+<xsl:otherwise><xsl:text>, </xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:for-each>
+</xsl:for-each>
+</span>
+</xsl:if>
+
+<xsl:if test="marc:datafield[@tag=540]">
+<span class="results_summary">
+<span class="label">Title added by the cataloguer : </span>
+<xsl:for-each select="marc:datafield[@tag=540]">
+<xsl:for-each select="marc:subfield">
+<xsl:value-of select="text()"/>
+<xsl:choose>
+<xsl:when test="position()=last()">
+<xsl:text>.</xsl:text>
+</xsl:when>
+<xsl:otherwise><xsl:text>, </xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:for-each>
+</xsl:for-each>
+</span>
+</xsl:if>
+
+<xsl:if test="marc:datafield[@tag=541]">
+<span class="results_summary">
+<span class="label">Title translated by the cataloger : </span>
+<xsl:for-each select="marc:datafield[@tag=541]">
+<xsl:for-each select="marc:subfield">
+<xsl:value-of select="text()"/>
+<xsl:choose>
+<xsl:when test="position()=last()">
+<xsl:text>.</xsl:text>
+</xsl:when>
+<xsl:otherwise><xsl:text>, </xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:for-each>
+</xsl:for-each>
+</span>
+</xsl:if>
+
+
+<xsl:if test="marc:datafield[@tag=099]/marc:subfield[@code='t']">
+  <span class="results_summary">
+    <span class="label">Category of document : </span>
+    <xsl:for-each select="marc:datafield[@tag=099]/marc:subfield[@code='t']">
+      <xsl:value-of select="."/>
+      <xsl:if test="not(position()=last())"><xsl:text> ; </xsl:text></xsl:if>
+    </xsl:for-each>
+  </span>
+</xsl:if>
+
+ <xsl:call-template name="tag_7xx">
+ <xsl:with-param name="tag">700</xsl:with-param>
+ <xsl:with-param name="label">Author(s)</xsl:with-param>
+ </xsl:call-template>
+
+ <xsl:call-template name="tag_71x">
+ <xsl:with-param name="tag">710</xsl:with-param>
+ <xsl:with-param name="label">Author(s)</xsl:with-param>
+ </xsl:call-template>
+
+ <xsl:call-template name="tag_7xx">
+ <xsl:with-param name="tag">701</xsl:with-param>
+ <xsl:with-param name="label">Author(s)</xsl:with-param>
+ </xsl:call-template>
+
+ <xsl:call-template name="tag_7xx">
+ <xsl:with-param name="tag">702</xsl:with-param>
+ <xsl:with-param name="label">Author(s)</xsl:with-param>
+ </xsl:call-template>
+
+ <xsl:call-template name="tag_71x">
+ <xsl:with-param name="tag">711</xsl:with-param>
+ <xsl:with-param name="label">Author(s)</xsl:with-param>
+ </xsl:call-template>
+
+ <xsl:call-template name="tag_71x">
+ <xsl:with-param name="tag">712</xsl:with-param>
+ <xsl:with-param name="label">Author(s)</xsl:with-param>
+ </xsl:call-template>
+
+<xsl:if test="marc:datafield[@tag=101]"> 
+<span class="results_summary">
+<span class="label">Language(s) : </span>
+<xsl:for-each select="marc:datafield[@tag=101]">
+<xsl:for-each select="marc:subfield">
+<xsl:value-of select="text()"/>
+ <!--<xsl:choose>
+ <xsl:when test="@code='b'">du texte intermédiaire, </xsl:when>
+ <xsl:when test="@code='c'">de l'oeuvre originale, </xsl:when>
+ <xsl:when test="@code='d'">du résumé, </xsl:when>
+ <xsl:when test="@code='e'">de la table des matières, </xsl:when>
+ <xsl:when test="@code='f'">de la page de titre, </xsl:when>
+ <xsl:when test="@code='g'">du titre propre, </xsl:when>
+ <xsl:when test="@code='h'">du livret ou des paroles, </xsl:when>
+ <xsl:when test="@code='i'">du matériel d'accompagnement, </xsl:when>
+ <xsl:when test="@code='j'">des sous-titres </xsl:when>n> </xsl:choose>
+ <xsl:value-of select="text()"/>-->
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text>.</xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> ; </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+ </xsl:for-each>
+ </span>
+ </xsl:if>
+
+<xsl:if test="marc:datafield[@tag=102]">
+<span class="results_summary">
+<span class="label">Country : </span>
+<xsl:for-each select="marc:datafield[@tag=102]">
+<xsl:for-each select="marc:subfield">
+<xsl:value-of select="text()"/>
+<xsl:choose>
+<xsl:when test="position()=last()">
+<xsl:text>.</xsl:text>
+</xsl:when>
+<xsl:otherwise><xsl:text>, </xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:for-each>
+</xsl:for-each>
+</span>
+</xsl:if>
+
+<xsl:if test="marc:datafield[@tag=205]">
+<span class="results_summary">
+<span class="label">Edition : </span>
+<xsl:for-each select="marc:datafield[@tag=205]">
+<xsl:for-each select="marc:subfield">
+<xsl:value-of select="text()"/>
+<xsl:choose>
+<xsl:when test="position()=last()">
+<xsl:text>.</xsl:text>
+</xsl:when>
+<xsl:otherwise><xsl:text>, </xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:for-each>
+</xsl:for-each>
+</span>
+</xsl:if>
+
+<xsl:if test="(marc:datafield[@tag=214] or marc:datafield[@tag=210])">
+<xsl:choose>
+<xsl:when test="(marc:datafield[@tag=214]/marc:subfield[@code='r'])">
+<xsl:call-template name="tag_214_r" />
+</xsl:when>
+<xsl:when test="(marc:datafield[@tag=214]/marc:subfield[@code='s'])">
+<xsl:call-template name="tag_214_s" />
+</xsl:when>
+<xsl:when test="(marc:datafield[@tag=210]/marc:subfield[@code='r'])">
+<xsl:call-template name="tag_210_r" />
+</xsl:when>
+<xsl:when test="(marc:datafield[@tag=210]/marc:subfield[@code='s'])">
+<xsl:call-template name="tag_210_s" />
+</xsl:when>
+<xsl:when test="(marc:datafield[@tag=214] and  marc:datafield[@tag=210])">
+<xsl:call-template name="tag_214" />
+</xsl:when>
+<xsl:when test="(marc:datafield[@tag=214])">
+<xsl:call-template name="tag_214" />
+</xsl:when>
+<xsl:when test="(marc:datafield[@tag=210])">
+<xsl:call-template name="tag_210" />
+</xsl:when>
+</xsl:choose>
+</xsl:if>
+
+<xsl:call-template name="tag_215" />
+
+<xsl:if test="marc:controlfield[@tag=009]">
+<span class="results_summary">
+<span class="label">SUDOC : </span>
+<a><xsl:attribute name="href">http://www.sudoc.fr/<xsl:value-of select="$ppn"/></xsl:attribute><xsl:value-of select="$ppn"/></a>
+</span>
+</xsl:if>
+
+<!--ISBN-->
+<xsl:if test="(marc:datafield[@tag=010]/marc:subfield[@code='a']) or (marc:datafield[@tag=010]/marc:subfield[@code='b']) or (marc:datafield[@tag=010]/marc:subfield[@code='z'])">
+
+
+ <span class="results_summary">
+<span class="label">ISBN : </span>
+ <xsl:for-each select="marc:datafield[@tag=010]">
+
+ <xsl:choose>
+ <xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='b']) and (marc:subfield[@code='z'])">
+ <xsl:value-of select="marc:subfield[@code='a']"/>
+ <xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='z']"/><xsl:text>(erroné)</xsl:text>
+<xsl:text>  </xsl:text>
+<xsl:text>(</xsl:text><xsl:value-of select="marc:subfield[@code='b']"/><xsl:text>)</xsl:text>
+ </xsl:when>
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='b'])">
+ <xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text>  </xsl:text>
+<xsl:text>(</xsl:text><xsl:value-of select="marc:subfield[@code='b']"/><xsl:text>)</xsl:text>
+ </xsl:when>
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='z'])">
+ <xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='z']"/><xsl:text>(erroné)</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='b']) and (marc:subfield[@code='z'])">
+ <xsl:value-of select="marc:subfield[@code='z']"/>
+<xsl:text>(erroné) </xsl:text><xsl:text>(</xsl:text>
+<xsl:value-of select="marc:subfield[@code='b']"/><xsl:text>)</xsl:text>
+</xsl:when>
+ <xsl:when test="(marc:subfield[@code='a'])">
+ <xsl:value-of select="marc:subfield[@code='a']"/>
+ </xsl:when>
+<xsl:when test="(marc:subfield[@code='b'])">
+ <xsl:value-of select="marc:subfield[@code='b']"/>
+ </xsl:when>
+<xsl:when test="(marc:subfield[@code='d'])">
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+ </xsl:when>
+</xsl:choose>
+<xsl:choose>
+<xsl:when test="position()=last()">
+<xsl:text> </xsl:text>
+</xsl:when>
+<xsl:otherwise><xsl:text> .- </xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:for-each>
+</span>
+</xsl:if>
+
+
+
+
+<xsl:if test="marc:datafield[@tag=010]/marc:subfield[@code='d']">
+<span class="results_summary">
+<span class="label">Price : </span>
+<xsl:for-each select="marc:datafield[@tag=010]">
+<xsl:variable name="isbn" select="marc:subfield[@code='d']"/>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:choose>
+<xsl:when test="position()=last()">
+<xsl:text>.</xsl:text>
+</xsl:when>
+<xsl:otherwise>
+<xsl:text> ; </xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:for-each>
+</span>
+</xsl:if>
+
+<xsl:if test="marc:datafield[@tag=011]">
+<span class="results_summary">
+<span class="label">ISSN : </span>
+<xsl:for-each select="marc:datafield[@tag=011]">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:choose>
+<xsl:when test="position()=last()">
+<xsl:text>.</xsl:text>
+</xsl:when>
+<xsl:otherwise>
+<xsl:text>; </xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:for-each>
+</span>
+</xsl:if>
+
+ <xsl:call-template name="tag_title">
+ <xsl:with-param name="tag">225</xsl:with-param>
+ <xsl:with-param name="label">Collection</xsl:with-param>
+ </xsl:call-template>
+
+
+<!--410 Collection-->
+<xsl:for-each select="marc:datafield[@tag=410]">
+<span class="results_summary">
+<span class="label">Collection : </span>
+<xsl:choose>
+<xsl:when test="(marc:subfield[@code='9']) and (marc:subfield[@code='x']) and (marc:subfield[@code='v'])">
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?q=an:<xsl:value-of select="marc:subfield[@code='9']"/></xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:element>
+<xsl:text>, ISSN </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?idx=ns&amp;q=<xsl:value-of select="marc:subfield[@code='x']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x']"/></xsl:element>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='v']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='9'])  and (marc:subfield[@code='v'])">
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?q=an:<xsl:value-of select="marc:subfield[@code='9']"/></xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:element>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='v']"/>
+      </xsl:when>
+<xsl:when test="(marc:subfield[@code='9']) and (marc:subfield[@code='x'])">
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?q=an:<xsl:value-of select="marc:subfield[@code='9']"/></xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:element>
+<xsl:text>, ISSN </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?idx=ns&amp;q=<xsl:value-of select="marc:subfield[@code='x']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x']"/></xsl:element>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='t']) and (marc:subfield[@code='x']) and (marc:subfield[@code='v'])">
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?idx=Title-series&amp;q=<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='t']"/></xsl:element>
+<xsl:text>, ISSN </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?idx=ns&amp;q=<xsl:value-of select="marc:subfield[@code='x']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x']"/></xsl:element>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='v']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='t'])  and (marc:subfield[@code='v'])">
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?idx=Title-series&amp;q=<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='t']"/></xsl:element>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='v']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='t'])">
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?idx=Title-series&amp;q=<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='t']"/></xsl:element>
+</xsl:when>
+ </xsl:choose>
+</span>
+</xsl:for-each>
+
+
+
+<!--500 DE UNIFORME-->
+<xsl:for-each select="marc:datafield[@tag=500]">
+<span class="results_summary">
+<span class="label">Uniform title : </span>
+ <xsl:if test="marc:subfield[@code='a']">
+<xsl:text>[</xsl:text>
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:choose>
+<xsl:when test="(marc:subfield[@code='i']) and (marc:subfield[@code='m']) and  (marc:subfield[@code='k'])">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='i']"/>
+<xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='m']"/>
+<xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='k']"/>
+ <xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='i']) and (marc:subfield[@code='l'])">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='i']"/>
+<xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='l']"/>
+ <xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='m']) and (marc:subfield[@code='k'])">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='m']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='k']"/>
+ <xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='i']) and (marc:subfield[@code='k'])">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='i']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='k']"/>
+ <xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='i'][3])">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='i'][1]"/>
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='i'][2]"/>
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='i'][3]"/>
+ <xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='i'][2])">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='i'][1]"/>
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='i'][2]"/>
+ <xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='l'])">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='l']"/>
+ <xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:otherwise>
+<xsl:text>]</xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:if>
+ </span>
+ </xsl:for-each>
+
+
+<!--503 TITRE FORME-->
+<xsl:for-each select="marc:datafield[@tag=503]">
+ <span class="results_summary">
+<span class="label">Form title : </span>
+ <xsl:if test="marc:subfield[@code='a']">
+<xsl:text>[</xsl:text>
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:choose>
+<xsl:when test="(marc:subfield[@code='e']) and (marc:subfield[@code='i']) and  (marc:subfield[@code='m']) and  (marc:subfield[@code='n']) and (marc:subfield[@code='o']) and (marc:subfield[@code='j'])">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='i']"/>
+<xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='m']"/>
+<xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='n']"/>
+<xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='o']"/>
+<xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='j']"/>
+ <xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='e']) and (marc:subfield[@code='m']) and (marc:subfield[@code='n']) and (marc:subfield[@code='o']) and (marc:subfield[@code='j'])">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='m']"/>
+<xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='n']"/>
+<xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='o']"/>
+<xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='j']"/>
+ <xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='m']) and (marc:subfield[@code='n']) and (marc:subfield[@code='o']) and (marc:subfield[@code='j'])">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='m']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='n']"/>
+<xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='o']"/>
+<xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='j']"/>
+ <xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='e']) and (marc:subfield[@code='m']) and (marc:subfield[@code='n']) and (marc:subfield[@code='j'])">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='e']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='m']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='n']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='j']"/>
+<xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='m']) and (marc:subfield[@code='n']) and (marc:subfield[@code='j'])">
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='m']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='n']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='j']"/>
+<xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='e']) and (marc:subfield[@code='h']) and (marc:subfield[@code='j'])">
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='h']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='j']"/>
+<xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='e']) and (marc:subfield[@code='f']) and (marc:subfield[@code='h'])">
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='f']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='h']"/>
+<xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='e']) and (marc:subfield[@code='f'])">
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='f']"/>
+<xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='i']) and (marc:subfield[@code='n'])">
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='i']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='n']"/>
+<xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='m']) and (marc:subfield[@code='n'])">
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='m']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='n']"/>
+<xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='m']) and (marc:subfield[@code='j'])">
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='m']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='j']"/>
+<xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='m'])">
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='m']"/>
+<xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:otherwise>
+<xsl:text>]</xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:if>
+</span>
+</xsl:for-each>
+
+
+<!--517 AUTRE TITRE-->
+<xsl:for-each select="marc:datafield[@tag=517]">
+<span class="results_summary">
+<span class="label">Other title : </span>
+ <xsl:if test="marc:subfield[@code='a']">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:choose>
+<xsl:when test="(marc:subfield[@code='e']) and (marc:subfield[@code='h']) and  (marc:subfield[@code='i'])">
+ <xsl:text>: </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='h']"/>
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='i']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='e'])">
+ <xsl:text>: </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='e']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='j'])">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='j']"/>
+</xsl:when>
+</xsl:choose>
+</xsl:if>
+</span>
+</xsl:for-each>
+
+
+<xsl:if test="marc:datafield[@tag=686]">
+<span class="results_summary">
+<span class="label">Other classification :  </span>
+<xsl:for-each select="marc:datafield[@tag=686]">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:if test="marc:subfield[@code='2']">
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='2']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='z']">
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='z']"/>
+</xsl:if>
+<xsl:if test="not (position()=last())">
+<xsl:text> ; </xsl:text>
+</xsl:if>
+</xsl:for-each>
+</span>
+</xsl:if>
+
+<xsl:if test="marc:datafield[@tag=675]">
+<span class="results_summary">
+<span class="label">Classification - CDU : </span>
+<xsl:for-each select="marc:datafield[@tag=675]">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:if test="marc:subfield[@code='b']">
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='b']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='c']">
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:if>
+<xsl:if test="not (position()=last())"><xsl:text> ; </xsl:text></xsl:if>
+</xsl:for-each>
+</span>
+</xsl:if>
+
+
+<xsl:if test="marc:datafield[@tag=676]">
+<span class="results_summary">
+<span class="label">Classification - Dewey : </span>
+<xsl:for-each select="marc:datafield[@tag=676]">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:if test="marc:subfield[@code='b']">
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='b']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='c']">
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:if>
+<xsl:if test="not (position()=last())"><xsl:text> ; </xsl:text></xsl:if>
+</xsl:for-each>
+</span>
+</xsl:if>
+
+
+
+<!--onglet Description-->
+<div id="tab-content-descr" class="tab-content">
+<p>
+ <xsl:if test="marc:datafield[@tag=300]">
+ <span class="results_summary">
+ <span class="label">Note : </span>
+ <xsl:for-each select="marc:datafield[@tag=300]">
+  <xsl:for-each select="marc:subfield[@code='a']">
+<xsl:value-of select="."/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> | </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+ </xsl:for-each>
+ </span>
+ </xsl:if>
+</p>
+<p>
+<xsl:if test="marc:datafield[@tag=303]">
+ <span class="results_summary">
+ <span class="label">Note about the bibliographic description : </span>
+<xsl:for-each select="marc:datafield[@tag=303]">
+ <xsl:for-each select="marc:subfield[@code='a']">
+<xsl:value-of select="."/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> | </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+</xsl:for-each>
+</span>
+</xsl:if>
+</p>
+<p>
+<xsl:if test="marc:datafield[@tag=304]">
+ <span class="results_summary">
+ <span class="label">Note about the title and the authors : </span>
+<xsl:for-each select="marc:datafield[@tag=304]">
+ <xsl:for-each select="marc:subfield[@code='a']">
+<xsl:value-of select="."/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> | </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+</xsl:for-each>
+</span>
+</xsl:if>
+</p>
+<p>
+<xsl:if test="marc:datafield[@tag=305]">
+ <span class="results_summary">
+ <span class="label">Note about the edition and the history : </span>
+<xsl:for-each select="marc:datafield[@tag=305]">
+ <xsl:for-each select="marc:subfield[@code='a']">
+<xsl:value-of select="."/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> | </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+</xsl:for-each>
+</span>
+</xsl:if>
+</p>
+<p>
+<xsl:if test="marc:datafield[@tag=306]">
+ <span class="results_summary">
+ <span class="label">Note about the production : </span>
+<xsl:for-each select="marc:datafield[@tag=306]">
+ <xsl:for-each select="marc:subfield[@code='a']">
+<xsl:value-of select="."/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> | </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+</xsl:for-each>
+</span>
+</xsl:if>
+</p>
+<p>
+<xsl:if test="marc:datafield[@tag=307]">
+ <span class="results_summary">
+ <span class="label">Note about the material desscription : </span>
+<xsl:for-each select="marc:datafield[@tag=307]">
+ <xsl:for-each select="marc:subfield[@code='a']">
+<xsl:value-of select="."/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> | </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+</xsl:for-each>
+</span>
+</xsl:if>
+</p>
+<p>
+<xsl:if test="marc:datafield[@tag=308]">
+ <span class="results_summary">
+ <span class="label">Note about the collection : </span>
+<xsl:for-each select="marc:datafield[@tag=308]">
+ <xsl:for-each select="marc:subfield[@code='a']">
+<xsl:value-of select="."/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> | </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+</xsl:for-each>
+</span>
+</xsl:if>
+</p>
+<p>
+<xsl:if test="marc:datafield[@tag=310]">
+ <span class="results_summary">
+ <span class="label">Note about the availability : </span>
+<xsl:for-each select="marc:datafield[@tag=310]">
+ <xsl:for-each select="marc:subfield[@code='a']">
+<xsl:value-of select="."/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> | </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+</xsl:for-each>
+</span>
+</xsl:if>
+</p>
+<p>
+<xsl:if test="marc:datafield[@tag=311]">
+ <span class="results_summary">
+ <span class="label">Note about the links : </span>
+<xsl:for-each select="marc:datafield[@tag=311]">
+ <xsl:for-each select="marc:subfield[@code='a']">
+<xsl:value-of select="."/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> | </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+</xsl:for-each>
+</span>
+</xsl:if>
+</p>
+<p>
+<xsl:if test="marc:datafield[@tag=312]">
+ <span class="results_summary">
+ <span class="label">Note about the titles : </span>
+<xsl:for-each select="marc:datafield[@tag=312]">
+ <xsl:for-each select="marc:subfield[@code='a']">
+<xsl:value-of select="."/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> | </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+</xsl:for-each>
+</span>
+</xsl:if>
+</p>
+<p>
+<xsl:if test="marc:datafield[@tag=314]">
+ <span class="results_summary">
+ <span class="label">Note about the responsability : </span>
+<xsl:for-each select="marc:datafield[@tag=314]">
+ <xsl:for-each select="marc:subfield[@code='a']">
+<xsl:value-of select="."/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> | </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+</xsl:for-each>
+</span>
+</xsl:if>
+</p>
+<p>
+<xsl:if test="marc:datafield[@tag=315]">
+ <span class="results_summary">
+ <span class="label">Note about the source : </span>
+<xsl:for-each select="marc:datafield[@tag=315]">
+ <xsl:for-each select="marc:subfield[@code='a']">
+<xsl:value-of select="."/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> | </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+</xsl:for-each>
+</span>
+</xsl:if>
+</p>
+<!--316 Note sur l'exemplaire-->
+<p>
+<xsl:for-each select="marc:datafield[@tag=316]">
+ <span class="results_summary">
+ <span class="label">Note about the item : </span>
+<xsl:if test="(marc:subfield[@code='a'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text>. </xsl:text>
+</xsl:if>
+<xsl:if test="(marc:subfield[@code='5'])">
+<xsl:value-of select="marc:subfield[@code='5']"/>
+<xsl:text>. </xsl:text>
+</xsl:if>
+</span>
+</xsl:for-each>
+</p>
+<!--317 Note sur la provenance-->
+<p>
+<xsl:for-each select="marc:datafield[@tag=317]">
+ <span class="results_summary">
+ <span class="label">Note about the provenance : </span>
+<xsl:if test="(marc:subfield[@code='a'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text>. </xsl:text>
+</xsl:if>
+<xsl:if test="(marc:subfield[@code='5'])">
+<xsl:value-of select="marc:subfield[@code='5']"/>
+<xsl:text>. </xsl:text>
+</xsl:if>
+</span>
+</xsl:for-each>
+</p>
+<p>
+<xsl:for-each select="marc:datafield[@tag=320]">
+ <span class="results_summary">
+ <span class="label">Note about the bibliographies and the index : </span>
+<xsl:if test="(marc:subfield[@code='a'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text>. </xsl:text>
+</xsl:if>
+<xsl:if test="(marc:subfield[@code='u'])">
+<xsl:value-of select="marc:subfield[@code='u']"/>
+<xsl:text>. </xsl:text>
+</xsl:if>
+</span>
+</xsl:for-each>
+</p>
+<p>
+<xsl:for-each select="marc:datafield[@tag=321]">
+ <span class="results_summary">
+ <span class="label">Note about the index, extract : </span>
+<xsl:if test="(marc:subfield[@code='a'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text>. </xsl:text>
+</xsl:if>
+<xsl:if test="(marc:subfield[@code='u'])">
+<xsl:value-of select="marc:subfield[@code='u']"/>
+<xsl:text>. </xsl:text>
+</xsl:if>
+</span>
+</xsl:for-each>
+</p>
+<p>
+<xsl:for-each select="marc:datafield[@tag=322]">
+ <span class="results_summary">
+ <span class="label">Note about the music : </span>
+<xsl:if test="(marc:subfield[@code='a'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text>. </xsl:text>
+</xsl:if>
+<xsl:if test="(marc:subfield[@code='u'])">
+<xsl:value-of select="marc:subfield[@code='u']"/>
+<xsl:text>. </xsl:text>
+</xsl:if>
+</span>
+</xsl:for-each>
+</p>
+<p>
+<xsl:for-each select="marc:datafield[@tag=323]">
+ <span class="results_summary">
+ <span class="label">Note about the actors : </span>
+<xsl:if test="(marc:subfield[@code='a'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text>. </xsl:text>
+</xsl:if>
+<xsl:if test="(marc:subfield[@code='u'])">
+<xsl:value-of select="marc:subfield[@code='u']"/>
+<xsl:text>. </xsl:text>
+</xsl:if>
+</span>
+</xsl:for-each>
+</p>
+<p>
+<xsl:for-each select="marc:datafield[@tag=324]">
+ <span class="results_summary">
+ <span class="label">Note about original reproduction : </span>
+<xsl:if test="(marc:subfield[@code='a'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text>. </xsl:text>
+</xsl:if>
+<xsl:if test="(marc:subfield[@code='u'])">
+<xsl:value-of select="marc:subfield[@code='u']"/>
+<xsl:text>. </xsl:text>
+</xsl:if>
+</span>
+</xsl:for-each>
+</p>
+<p>
+<xsl:if test="marc:datafield[@tag=325]">
+ <span class="results_summary">
+ <span class="label">Note about reproduction : </span>
+<xsl:for-each select="marc:datafield[@tag=325]">
+ <xsl:for-each select="marc:subfield[@code='a']">
+<xsl:value-of select="."/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> | </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+</xsl:for-each>
+</span>
+</xsl:if>
+</p>
+<p>
+ <xsl:if test="marc:datafield[@tag=327]">
+  <span class="results_summary">
+ <span class="label">Note of content : </span>
+ <xsl:for-each select="marc:datafield[@tag=327]">
+ <xsl:for-each select="marc:subfield[@code='a']">
+<xsl:value-of select="."/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> | </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+  </xsl:for-each>
+</span>
+ </xsl:if>
+</p>
+<p>
+<xsl:if test="marc:datafield[@tag=326]">
+  <span class="results_summary">
+ <span class="label">Periodicity : </span>
+ <xsl:for-each select="marc:datafield[@tag=326]">
+ <xsl:value-of select="marc:subfield[@code='a']"/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text>; </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+ </span>
+ </xsl:if>
+ </p>
+ <p>
+ <xsl:if test="marc:datafield[@tag=328]">
+  <span class="results_summary">
+ <span class="label">Note of thesis : </span>
+ <xsl:for-each select="marc:datafield[@tag=328]">
+<xsl:for-each select="marc:subfield">
+ <xsl:value-of select="text()"/>
+ <xsl:choose><xsl:when test="position()=last()"><xsl:text> . </xsl:text></xsl:when><xsl:otherwise><xsl:text> - </xsl:text></xsl:otherwise></xsl:choose>
+ </xsl:for-each>
+ </xsl:for-each>
+ </span>
+ </xsl:if>
+</p>
+<p>
+<xsl:if test="marc:datafield[@tag=336]">
+  <span class="results_summary">
+ <span class="label">Type electronic source : </span>
+ <xsl:for-each select="marc:datafield[@tag=336]">
+<xsl:for-each select="marc:subfield">
+ <xsl:value-of select="text()"/>
+ <xsl:choose><xsl:when test="position()=last()"><xsl:text> . </xsl:text></xsl:when><xsl:otherwise><xsl:text> - </xsl:text></xsl:otherwise></xsl:choose>
+ </xsl:for-each>
+ </xsl:for-each>
+ </span>
+ </xsl:if>
+</p>
+<p>
+<xsl:if test="marc:datafield[@tag=337]">
+  <span class="results_summary">
+ <span class="label">Note of academic thesis : </span>
+ <xsl:for-each select="marc:datafield[@tag=337]">
+<xsl:for-each select="marc:subfield">
+ <xsl:value-of select="text()"/>
+ <xsl:choose><xsl:when test="position()=last()"><xsl:text> . </xsl:text></xsl:when><xsl:otherwise><xsl:text> - </xsl:text></xsl:otherwise></xsl:choose>
+ </xsl:for-each>
+ </xsl:for-each>
+ </span>
+ </xsl:if>
+</p>
+</div>
+
+
+
+<div id="tab-content-330">
+<xsl:if test="marc:datafield[@tag=330]">
+<span class="results_summary">
+<span class="label">Abstract : </span>
+<xsl:for-each select="marc:datafield[@tag=330]">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <br></br><xsl:text> </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+</xsl:for-each>
+</span>
+</xsl:if>
+</div>
+
+<!--onglet Table des matières-->
+<div id="tab-content-359">
+<xsl:for-each select="marc:datafield[@tag=359]">
+ <xsl:for-each select="node()">
+<dd><xsl:value-of select="."/></dd>
+ </xsl:for-each> </xsl:for-each>
+</div>
+
+<xsl:if test="marc:datafield[@tag=610]">
+<span class="results_summary">
+<span class="label">Subject : </span>
+<xsl:for-each select="marc:datafield[@tag=610]">
+<xsl:choose>
+<xsl:when test="contains(marc:subfield[@code='a'],'(')">
+<a>
+<xsl:attribute name="href">/cgi-bin/koha/opac-search.pl?q=su,phr:
+<xsl:value-of select="marc:subfield[@code='a']"/>-->
+<xsl:value-of select="substring-before(marc:subfield[@code='a'], '(')" />
+<xsl:value-of select="substring-before(substring-after(marc:subfield[@code='a'], '('), ')')" />
+<xsl:value-of select="substring-after(marc:subfield[@code='a'], ')')" />
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='a']"/>
+</a>
+</xsl:when>
+<xsl:otherwise>
+<a>
+<xsl:attribute name="href">/cgi-bin/koha/opac-search.pl?q=su,phr:<xsl:value-of select="marc:subfield[@code='a']"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='a']"/>
+</a>
+</xsl:otherwise>
+</xsl:choose>
+<xsl:choose>
+<xsl:when test="position()=last()">
+<xsl:text> </xsl:text>
+</xsl:when>
+<xsl:otherwise>
+<xsl:text> .  </xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:for-each>
+</span>
+</xsl:if>
+
+
+<!--<xsl:if test="marc:datafield[@tag=902]">
+<span class="results_summary">
+<span class="label">Level :</span> 
+ <xsl:for-each select="marc:datafield[@tag=902]">
+ <xsl:value-of select="marc:subfield[@code='a']"/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> .  </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+ </span>
+ </xsl:if>-->
+
+<!--<xsl:if test="marc:datafield[@tag=903]">
+<span class="results_summary">
+<span class="label">Domain : </span>
+<xsl:for-each select="marc:datafield[@tag=903]">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:value-of select="marc:subfield[@code='p']"/>
+<xsl:choose>
+<xsl:when test="position()=last()">
+<xsl:text> </xsl:text>
+</xsl:when>
+<xsl:otherwise>
+<xsl:text>; </xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:for-each>
+</span>
+</xsl:if>-->
+
+<!--
+<xsl:if test="marc:datafield[@tag=464]">
+<div class="panel panel-default results_summary">
+<div class="panel-heading" style="background-color:#FAFAFA">
+Content :
+</div>
+<div class="panel-body" style="height:190px;overflow:auto;background-color:#FAFAFA">
+<xsl:for-each select="marc:datafield[@tag=464]">
+<p>
+<xsl:choose>
+<xsl:when test="marc:subfield[@code='u']">
+<a>
+<xsl:attribute name="href"><xsl:value-of select="marc:subfield[@code='u']"/></xsl:attribute>
+<xsl:attribute name="title"><xsl:text>play-pause</xsl:text></xsl:attribute>
+<xsl:attribute name="class"><xsl:text>sm2_button</xsl:text></xsl:attribute>
+<xsl:text>play-pause</xsl:text>
+<img id="play" width="18" height="18"><xsl:attribute name="src">/public/images/play.png</xsl:attribute></img>
+</a>
+</xsl:when>
+<xsl:otherwise>
+<img id="noplay" width="18" height="18"><xsl:attribute name="src">/public/images/noplay.png</xsl:attribute></img>
+</xsl:otherwise>
+</xsl:choose>
+<xsl:text> - </xsl:text>
+<xsl:if test="marc:subfield[@code='h']">
+<xsl:value-of select="marc:subfield[@code='h']"/><xsl:text> - </xsl:text>
+</xsl:if>
+<xsl:choose>
+<xsl:when test="marc:subfield[@code='t']"><xsl:value-of select="marc:subfield[@code='t']"/></xsl:when>
+<xsl:when test="marc:subfield[@code='z']"><xsl:value-of select="marc:subfield[@code='z']"/></xsl:when>
+<xsl:otherwise>Titre inconnu</xsl:otherwise>
+</xsl:choose>
+<xsl:if test="marc:subfield[@code='a']">
+<i>
+<xsl:for-each select="marc:subfield[@code='a']">
+<xsl:text> - </xsl:text><xsl:value-of select="."/>
+</xsl:for-each>
+</i>
+</xsl:if>
+</p>
+</xsl:for-each>
+</div>
+</div>
+</xsl:if>
+-->
+
+
+<!--Etat de collection-->
+<xsl:if test="marc:datafield[@tag=923]">
+    <dt class="prolabelxslt">Summary of collections</dt>
+         <xsl:for-each select="marc:datafield[@tag=923]">
+ <xsl:if test="marc:subfield[@code='r']">
+            <xsl:if test="marc:subfield[@code='b']">
+              <dd>
+              <xsl:if test="marc:subfield[@code='b']">
+                        <xsl:call-template name="RCR">
+                            <xsl:with-param name="code" select="marc:subfield[@code='b']"/>
+                        </xsl:call-template>
+                  </xsl:if>
+                      <xsl:if test="marc:subfield[@code='r']">
+                  <xsl:text> : </xsl:text>
+                  <span class="statutdispo">
+                                <xsl:value-of select="marc:subfield[@code='r']"/>
+                  </span>
+                      </xsl:if>
+              </dd>
+            </xsl:if>
+            <xsl:if test="marc:subfield[@code='W']">
+              <dd>
+                <span class="profctxslt">
+                  <xsl:text>Missing : </xsl:text>
+                  <xsl:value-of select="marc:subfield[@code='W']"/>
+                </span>
+              </dd>
+            </xsl:if>
+                        <xsl:if test="marc:subfield[@code='Z']">
+              <dd>
+                <span class="profctxslt">
+                  <xsl:text>Notes : </xsl:text>
+                  <xsl:value-of select="marc:subfield[@code='Z']"/>
+                </span>
+              </dd>
+            </xsl:if>
+<xsl:if test="marc:subfield[@code='a'] or marc:subfield[@code='c'] or marc:subfield[@code='d']">
+              <dd>
+                <span class="profctxslt">
+                <xsl:if test="marc:subfield[@code='a']">
+                  <xsl:text>Callnumber : </xsl:text>
+                  <xsl:value-of select="marc:subfield[@code='a']" />
+                </xsl:if>
+                <xsl:if test="marc:subfield[@code='c']">
+                    <xsl:choose>
+                      <xsl:when test="marc:subfield[@code='a']">
+                        <xsl:text> ; Localisation : </xsl:text>
+                      </xsl:when>
+                      <xsl:otherwise>
+                        <xsl:text>Localisation : </xsl:text>
+                      </xsl:otherwise>
+                    </xsl:choose>
+                  <xsl:value-of select="marc:subfield[@code='c']" />
+                </xsl:if>
+                <xsl:if test="marc:subfield[@code='d']">
+                    <xsl:choose>
+                      <xsl:when test="marc:subfield[@code='a'] or marc:subfield[@code='d']">
+                        <xsl:text> ; </xsl:text>
+                      </xsl:when>
+                      <xsl:otherwise>
+                      </xsl:otherwise>
+                    </xsl:choose>
+                  <xsl:value-of select="marc:subfield[@code='d']" />
+                </xsl:if>
+              </span>
+              </dd>
+            </xsl:if>
+ </xsl:if>
+         </xsl:for-each>
+                  <xsl:for-each select="marc:datafield[@tag=930]">
+                        <xsl:if test="marc:subfield[@code='z'] or marc:subfield[@code='p']">
+                        <dd>
+                       <!--<span class="profctxslt">-->
+                        <span class="profctxslt">
+                                <xsl:text>Conservation : </xsl:text>
+                                        <xsl:value-of select="marc:subfield[@code='z']" />
+                                        <xsl:text> (</xsl:text>
+                                        <xsl:value-of select="marc:subfield[@code='p']" />
+                                        <xsl:text>)</xsl:text>
+                        </span>
+                        </dd>
+                        </xsl:if>
+                  </xsl:for-each>
+</xsl:if>
+
+<xsl:if test="marc:datafield[@tag=924]">
+    <dt class="prolabelxslt">Missing numbers</dt>
+         <xsl:for-each select="marc:datafield[@tag=924]">
+ <xsl:if test="marc:subfield[@code='r']">
+            <xsl:if test="marc:subfield[@code='b']">
+              <dd>
+              <xsl:if test="marc:subfield[@code='b']">
+                        <xsl:call-template name="RCR">
+                            <xsl:with-param name="code" select="marc:subfield[@code='b']"/>
+                        </xsl:call-template>
+                  </xsl:if>
+                      <xsl:if test="marc:subfield[@code='r']">
+                  <xsl:text> : </xsl:text>
+                  <span class="statutdispo">
+                                <xsl:value-of select="marc:subfield[@code='r']"/>
+                  </span>
+                      </xsl:if>
+              </dd>
+            </xsl:if>
+            <xsl:if test="marc:subfield[@code='W']">
+              <dd>
+                <span class="profctxslt">
+                  <xsl:text>Lacunes : </xsl:text>
+                  <xsl:value-of select="marc:subfield[@code='W']"/>
+                </span>
+              </dd>
+            </xsl:if>
+                        <xsl:if test="marc:subfield[@code='Z']">
+              <dd>
+                <span class="profctxslt">
+                  <xsl:text>Notes : </xsl:text>
+                  <xsl:value-of select="marc:subfield[@code='Z']"/>
+                </span>
+              </dd>
+            </xsl:if>
+<xsl:if test="marc:subfield[@code='a'] or marc:subfield[@code='c'] or marc:subfield[@code='d']">
+              <dd>
+                <span class="profctxslt">
+                <xsl:if test="marc:subfield[@code='a']">
+                  <xsl:text>Callnumber : </xsl:text>
+                  <xsl:value-of select="marc:subfield[@code='a']" />
+                </xsl:if>
+                <xsl:if test="marc:subfield[@code='c']">
+                    <xsl:choose>
+                      <xsl:when test="marc:subfield[@code='a']">
+                        <xsl:text> ; Localisation : </xsl:text>
+                      </xsl:when>
+                      <xsl:otherwise>
+                        <xsl:text>Localisation : </xsl:text>
+                      </xsl:otherwise>
+                    </xsl:choose>
+                  <xsl:value-of select="marc:subfield[@code='c']" />
+                </xsl:if>
+                <xsl:if test="marc:subfield[@code='d']">
+                    <xsl:choose>
+                      <xsl:when test="marc:subfield[@code='a'] or marc:subfield[@code='d']">
+                        <xsl:text> ; </xsl:text>
+                      </xsl:when>
+                      <xsl:otherwise>
+                      </xsl:otherwise>
+                    </xsl:choose>
+                  <xsl:value-of select="marc:subfield[@code='d']" />
+                </xsl:if>
+              </span>
+              </dd>
+            </xsl:if>
+ </xsl:if>
+         </xsl:for-each>
+                  <xsl:for-each select="marc:datafield[@tag=930]">
+                        <xsl:if test="marc:subfield[@code='z'] or marc:subfield[@code='p']">
+                        <dd>
+                       <!--<span class="profctxslt">-->
+                        <span class="profctxslt">
+                                <xsl:text>Conservation : </xsl:text>
+                                        <xsl:value-of select="marc:subfield[@code='z']" />
+                                        <xsl:text> (</xsl:text>
+                                        <xsl:value-of select="marc:subfield[@code='p']" />
+                                        <xsl:text>)</xsl:text>
+                        </span>
+                        </dd>
+                        </xsl:if>
+                  </xsl:for-each>
+</xsl:if>
+
+
+
+
+
+
+<xsl:for-each select="marc:datafield[@tag=600]">
+<span class="results_summary">
+<span class="label">Subject - name : </span>
+<xsl:if test="marc:subfield[@code='a']">
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text>+</xsl:text> <xsl:if test="marc:subfield[@code='b']!=''"><xsl:value-of select="marc:subfield[@code='b']"/></xsl:if>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='a']"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='b']">
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='b']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='d']">
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='c']">
+<xsl:text>, </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='c']"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='f']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='f']"/>
+<xsl:text>) </xsl:text>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='x']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:element>
+<xsl:if test="marc:subfield[@code='x'][2]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][2]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='x'][3]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][3]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][3]"/></xsl:element>
+</xsl:if>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='y']">
+<xsl:text> -- </xsl:text>
+<xsl:value-of select="marc:subfield[@code='y']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='z']">
+<xsl:text> -- </xsl:text>
+<xsl:value-of select="marc:subfield[@code='z']"/>
+</xsl:if>
+<xsl:text> | </xsl:text>
+<!-- recherche sur tous les mots-->
+<xsl:element name="a">
+<xsl:attribute name="href">/cgi-bin/koha/opac-search.pl?idx=su&amp;q=
+<xsl:choose>
+        <xsl:when test="contains(marc:subfield[@code='a'],'(')">
+          <xsl:value-of select="substring-before(marc:subfield[@code='a'], '(')" />
+          <xsl:value-of select="substring-before(substring-after(marc:subfield[@code='a'], '('), ')')" />
+          <xsl:value-of select="substring-after(marc:subfield[@code='a'], ')')" />
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="marc:subfield[@code='a']" />
+        </xsl:otherwise>
+      </xsl:choose> 
+<xsl:if test="marc:subfield[@code='b'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='b']!=''"><xsl:value-of select="marc:subfield[@code='b']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='c'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='c']!=''"><xsl:value-of select="marc:subfield[@code='c']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='d'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='d']!=''"><xsl:value-of select="marc:subfield[@code='d']"/></xsl:if><xsl:if test="marc:subfield[@code='x'][1] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][1]!=''"><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][2] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][2]!=''"><xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][3] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][3]!=''"><xsl:value-of select="marc:subfield[@code='x'][3]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='z'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='z']!=''"><xsl:value-of select="marc:subfield[@code='z']"/></xsl:if>
+</xsl:attribute>
+<xsl:attribute name="title">Search on all subject words</xsl:attribute>
+<i class="fa fa-search"></i>
+</xsl:element>
+</span>
+</xsl:for-each>
+
+
+<xsl:for-each select="marc:datafield[@tag=601]">
+<span class="results_summary">
+<span class="label">Subject - Collectivities : </span>
+<xsl:if test="marc:subfield[@code='a']">
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='a']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='a']"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='b']">
+<xsl:text>. </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='b'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='b'][1]"/></xsl:element>
+<xsl:if test="marc:subfield[@code='b'][2]">
+<xsl:text>. </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='b'][2]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='b'][2]"/></xsl:element>
+</xsl:if>
+
+<xsl:if test="marc:subfield[@code='b'][3]">
+<xsl:text>. </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='b'][3]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='b'][3]"/></xsl:element>
+</xsl:if>
+
+</xsl:if>
+<xsl:if test="marc:subfield[@code='c']">
+<xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+ </xsl:if>
+
+<xsl:choose>
+<xsl:when test="(marc:subfield[@code='d']) and (marc:subfield[@code='f']) and (marc:subfield[@code='e'])">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:text> ; </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='f']"/>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='d']) and (marc:subfield[@code='f'])">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:text> ; </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='f']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='d']) and (marc:subfield[@code='e'])">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:text> ; </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='e']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='e']) and (marc:subfield[@code='f'])">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='f']"/>
+<xsl:text> ; </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='e']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+<xsl:when test="marc:subfield[@code='d']">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+</xsl:choose>
+
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='x']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:element>
+<xsl:if test="marc:subfield[@code='x'][2]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][2]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='x'][3]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][3]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][3]"/></xsl:element></xsl:if>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='y']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='y']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='y']"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='z']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='z']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='z']"/></xsl:element>
+</xsl:if>
+<xsl:text> | </xsl:text>
+<!-- recherche sur tous les mots -->
+<xsl:element name="a">
+<xsl:attribute name="href">/cgi-bin/koha/opac-search.pl?idx=su&amp;q=
+<xsl:choose>
+        <xsl:when test="contains(marc:subfield[@code='a'],'(')">
+          <xsl:value-of select="substring-before(marc:subfield[@code='a'], '(')" />
+          <xsl:value-of select="substring-before(substring-after(marc:subfield[@code='a'], '('), ')')" />
+          <xsl:value-of select="substring-after(marc:subfield[@code='a'], ')')" />
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="marc:subfield[@code='a']" />
+        </xsl:otherwise>
+      </xsl:choose> 
+<xsl:if test="marc:subfield[@code='b'][1]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='b'][1]!=''"><xsl:value-of select="marc:subfield[@code='b'][1]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='b'][2]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='b'][2]!=''"><xsl:value-of select="marc:subfield[@code='b'][2]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='b'][3]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='b'][3]!=''"><xsl:value-of select="marc:subfield[@code='b'][3]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][1]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][1]!=''"><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][2]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][2]!=''"><xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][3]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][3]!=''"><xsl:value-of select="marc:subfield[@code='x'][3]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='y'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='y']!=''"><xsl:value-of select="marc:subfield[@code='y']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='z'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='z']!=''"><xsl:value-of select="marc:subfield[@code='z']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='j'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='j']!=''"><xsl:value-of select="marc:subfield[@code='j']"/></xsl:if>
+</xsl:attribute>
+<xsl:attribute name="title">Search on all subject words</xsl:attribute>
+<i class="fa fa-search"></i>
+</xsl:element>
+</span>
+</xsl:for-each>
+
+
+<xsl:for-each select="marc:datafield[@tag=602]">
+<span class="results_summary">
+<span class="label">Subject –  Name of family : </span>
+<xsl:if test="marc:subfield[@code='a']">
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='a']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='a']"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='b']">
+<xsl:text>. </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='b'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='b'][1]"/></xsl:element>
+<xsl:if test="marc:subfield[@code='b'][2]">
+<xsl:text>. </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='b'][2]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='b'][2]"/></xsl:element>
+</xsl:if>
+
+<xsl:if test="marc:subfield[@code='b'][3]">
+<xsl:text>. </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='b'][3]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='b'][3]"/></xsl:element>
+</xsl:if>
+
+       </xsl:if>
+<xsl:if test="marc:subfield[@code='c']">
+<xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+ </xsl:if>
+
+<xsl:choose>
+<xsl:when test="(marc:subfield[@code='d']) and (marc:subfield[@code='f']) and (marc:subfield[@code='e'])">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:text> ; </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='f']"/>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='d']) and (marc:subfield[@code='f'])">
+ <xsl:text> ( </xsl:text>
+</xsl:when>
+<xsl:when test="marc:subfield[@code='d']">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+</xsl:choose>
+
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='t']">
+<xsl:text> -- </xsl:text>
+<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='x']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:element>
+<xsl:if test="marc:subfield[@code='x'][2]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][2]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='x'][3]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][3]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][3]"/></xsl:element></xsl:if>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='y']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='y']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='y']"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='z']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='z']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='z']"/></xsl:element>
+</xsl:if>
+<xsl:text> | </xsl:text>
+<!-- recherche sur tous les mots -->
+<xsl:element name="a">
+<xsl:attribute name="href">/cgi-bin/koha/opac-search.pl?idx=su&amp;q=
+<xsl:choose>
+        <xsl:when test="contains(marc:subfield[@code='a'],'(')">
+          <xsl:value-of select="substring-before(marc:subfield[@code='a'], '(')" />
+          <xsl:value-of select="substring-before(substring-after(marc:subfield[@code='a'], '('), ')')" />
+          <xsl:value-of select="substring-after(marc:subfield[@code='a'], ')')" />
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="marc:subfield[@code='a']" />
+        </xsl:otherwise>
+      </xsl:choose> 
+<xsl:if test="marc:subfield[@code='b'][1]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='b'][1]!=''"><xsl:value-of select="marc:subfield[@code='b'][1]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='b'][2]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='b'][2]!=''"><xsl:value-of select="marc:subfield[@code='b'][2]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='b'][3]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='b'][3]!=''"><xsl:value-of select="marc:subfield[@code='b'][3]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][1]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][1]!=''"><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][2]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][2]!=''"><xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][3]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][3]!=''"><xsl:value-of select="marc:subfield[@code='x'][3]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='t']!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='t']!=''"><xsl:value-of select="marc:subfield[@code='t']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='y'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='y']!=''"><xsl:value-of select="marc:subfield[@code='y']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='z'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='z']!=''"><xsl:value-of select="marc:subfield[@code='z']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='j'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='j']!=''"><xsl:value-of select="marc:subfield[@code='j']"/></xsl:if>
+</xsl:attribute>
+<xsl:attribute name="title">Search on all subject words</xsl:attribute>
+<i class="fa fa-search"></i>
+</xsl:element>
+</span>
+</xsl:for-each>
+
+
+<xsl:for-each select="marc:datafield[@tag=604]">
+<span class="results_summary">
+<span class="label">Subject –  Author/Title : </span>
+<xsl:if test="marc:subfield[@code='a']">
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='a']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='a']"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='b']">
+<xsl:text>. </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='b'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='b'][1]"/></xsl:element>
+<xsl:if test="marc:subfield[@code='b'][2]">
+<xsl:text>. </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='b'][2]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='b'][2]"/></xsl:element>
+</xsl:if>
+
+<xsl:if test="marc:subfield[@code='b'][3]">
+<xsl:text>. </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='b'][3]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='b'][3]"/></xsl:element>
+</xsl:if>
+
+       </xsl:if>
+<xsl:if test="marc:subfield[@code='c']">
+<xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+ </xsl:if>
+
+<xsl:choose>
+<xsl:when test="(marc:subfield[@code='d']) and (marc:subfield[@code='f']) and (marc:subfield[@code='e'])">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:text> ; </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='f']"/>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='d']) and (marc:subfield[@code='f'])">
+ <xsl:text> ( </xsl:text>
+</xsl:when>
+<xsl:when test="marc:subfield[@code='d']">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+</xsl:choose>
+
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='t']">
+<xsl:text> -- </xsl:text>
+<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='x']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:element>
+<xsl:if test="marc:subfield[@code='x'][2]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][2]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='x'][3]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][3]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][3]"/></xsl:element></xsl:if>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='y']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='y']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='y']"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='z']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='z']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='z']"/></xsl:element>
+</xsl:if>
+<xsl:text> | </xsl:text>
+<!-- recherche sur tous les mots -->
+<xsl:element name="a">
+<xsl:attribute name="href">/cgi-bin/koha/opac-search.pl?idx=su&amp;q=
+<xsl:choose>
+        <xsl:when test="contains(marc:subfield[@code='a'],'(')">
+          <xsl:value-of select="substring-before(marc:subfield[@code='a'], '(')" />
+          <xsl:value-of select="substring-before(substring-after(marc:subfield[@code='a'], '('), ')')" />
+          <xsl:value-of select="substring-after(marc:subfield[@code='a'], ')')" />
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="marc:subfield[@code='a']" />
+        </xsl:otherwise>
+      </xsl:choose> 
+<xsl:if test="marc:subfield[@code='b'][1]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='b'][1]!=''"><xsl:value-of select="marc:subfield[@code='b'][1]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][1]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][1]!=''"><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][2]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][2]!=''"><xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][3]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][3]!=''"><xsl:value-of select="marc:subfield[@code='x'][3]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='t']!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='t']!=''"><xsl:value-of select="marc:subfield[@code='t']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='y'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='y']!=''"><xsl:value-of select="marc:subfield[@code='y']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='z'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='z']!=''"><xsl:value-of select="marc:subfield[@code='z']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='j'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='j']!=''"><xsl:value-of select="marc:subfield[@code='j']"/></xsl:if>
+</xsl:attribute>
+<xsl:attribute name="title">Search on all subject words</xsl:attribute>
+<i class="fa fa-search"></i>
+</xsl:element>
+</span>
+</xsl:for-each>
+
+
+<xsl:for-each select="marc:datafield[@tag=605]">
+<span class="results_summary">
+<span class="label">Subject –  Uniform title : </span>
+<xsl:if test="marc:subfield[@code='a']">
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='a']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='a']"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='b']">
+<xsl:text>. </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='b'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='b'][1]"/></xsl:element>
+<xsl:if test="marc:subfield[@code='b'][2]">
+<xsl:text>. </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='b'][2]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='b'][2]"/></xsl:element>
+</xsl:if>
+
+<xsl:if test="marc:subfield[@code='b'][3]">
+<xsl:text>. </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='b'][3]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='b'][3]"/></xsl:element>
+</xsl:if>
+
+       </xsl:if>
+<xsl:if test="marc:subfield[@code='c']">
+<xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+ </xsl:if>
+
+<xsl:choose>
+<xsl:when test="(marc:subfield[@code='d']) and (marc:subfield[@code='f']) and (marc:subfield[@code='e'])">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:text> ; </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='f']"/>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='d']) and (marc:subfield[@code='f'])">
+ <xsl:text> ( </xsl:text>
+</xsl:when>
+<xsl:when test="marc:subfield[@code='d']">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+</xsl:choose>
+
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='t']">
+<xsl:text> -- </xsl:text>
+<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='x']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:element>
+<xsl:if test="marc:subfield[@code='x'][2]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][2]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='x'][3]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][3]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][3]"/></xsl:element></xsl:if>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='y']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='y']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='y']"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='z']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='z']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='z']"/></xsl:element>
+</xsl:if>
+<xsl:text> | </xsl:text>
+<!-- recherche sur tous les mots -->
+<xsl:element name="a">
+<xsl:attribute name="href">/cgi-bin/koha/opac-search.pl?idx=su&amp;q=
+<xsl:choose>
+        <xsl:when test="contains(marc:subfield[@code='a'],'(')">
+          <xsl:value-of select="substring-before(marc:subfield[@code='a'], '(')" />
+          <xsl:value-of select="substring-before(substring-after(marc:subfield[@code='a'], '('), ')')" />
+          <xsl:value-of select="substring-after(marc:subfield[@code='a'], ')')" />
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="marc:subfield[@code='a']" />
+        </xsl:otherwise>
+      </xsl:choose> 
+<xsl:if test="marc:subfield[@code='b'][1]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='b'][1]!=''"><xsl:value-of select="marc:subfield[@code='b'][1]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][1]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][1]!=''"><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][2]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][2]!=''"><xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][3]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][3]!=''"><xsl:value-of select="marc:subfield[@code='x'][3]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='t']!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='t']!=''"><xsl:value-of select="marc:subfield[@code='t']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='y'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='y']!=''"><xsl:value-of select="marc:subfield[@code='y']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='z'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='z']!=''"><xsl:value-of select="marc:subfield[@code='z']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='j'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='j']!=''"><xsl:value-of select="marc:subfield[@code='j']"/></xsl:if>
+</xsl:attribute>
+<xsl:attribute name="title">Search on all subject words</xsl:attribute>
+<i class="fa fa-search"></i>
+</xsl:element>
+</span>
+</xsl:for-each>
+
+
+
+
+<xsl:for-each select="marc:datafield[@tag=606]">
+<span class="results_summary">
+<span class="label">Subject : </span>
+<xsl:if test="marc:subfield[@code='a']">
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='a']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='a']"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='j']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='j'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='j'][1]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='x']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:element>
+<xsl:if test="marc:subfield[@code='x'][2]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][2]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='x'][3]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][3]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][3]"/></xsl:element>
+</xsl:if>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='y']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='y'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='y'][1]"/></xsl:element>
+<xsl:if test="marc:subfield[@code='y'][2]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='y'][2]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='y'][2]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='y'][3]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='y'][3]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='y'][3]"/></xsl:element>
+</xsl:if>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='z']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='z']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='z']"/></xsl:element>
+</xsl:if>
+<xsl:text> | </xsl:text>
+<!-- recherche sur tous les mots -->
+<xsl:element name="a">
+<xsl:attribute name="href">/cgi-bin/koha/opac-search.pl?idx=su&amp;q=
+<xsl:choose>
+        <xsl:when test="contains(marc:subfield[@code='a'],'(')">
+          <xsl:value-of select="substring-before(marc:subfield[@code='a'], '(')" />
+          <xsl:value-of select="substring-before(substring-after(marc:subfield[@code='a'], '('), ')')" />
+          <xsl:value-of select="substring-after(marc:subfield[@code='a'], ')')" />
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="marc:subfield[@code='a']" />
+        </xsl:otherwise>
+      </xsl:choose> 
+<xsl:if test="marc:subfield[@code='x'][1]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][1]!=''"><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][2]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][2]!=''"><xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='y'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='y']!=''"><xsl:value-of select="marc:subfield[@code='y']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='z'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='z']!=''"><xsl:value-of select="marc:subfield[@code='z']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='j'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='j']!=''"><xsl:value-of select="marc:subfield[@code='j']"/></xsl:if>
+</xsl:attribute>
+<xsl:attribute name="title">Search on all subject words</xsl:attribute>
+<i class="fa fa-search"></i>
+</xsl:element>
+</span>
+</xsl:for-each>
+
+
+<xsl:for-each select="marc:datafield[@tag=607]">
+<span class="results_summary">
+<span class="label">Subject - geographical : </span>
+<xsl:if test="marc:subfield[@code='a']">
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='a']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='a']"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='x']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:element>
+<xsl:if test="marc:subfield[@code='x'][2]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][2]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='x'][3]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][3]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][3]"/></xsl:element>
+</xsl:if>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='y']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='y'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='y'][1]"/></xsl:element>
+<xsl:if test="marc:subfield[@code='y'][2]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='y'][2]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='y'][2]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='y'][3]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='y'][3]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='y'][3]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='y'][4]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='y'][4]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='y'][4]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='y'][5]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='y'][5]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='y'][5]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='y'][6]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='y'][6]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='y'][6]"/></xsl:element>
+</xsl:if>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='z']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='z']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='z']"/></xsl:element>
+</xsl:if>
+<xsl:text> | </xsl:text>
+<!-- recherche sur tous les mots -->
+<xsl:element name="a">
+<xsl:attribute name="href">/cgi-bin/koha/opac-search.pl?idx=su&amp;q=
+<xsl:choose>
+        <xsl:when test="contains(marc:subfield[@code='a'],'(')">
+          <xsl:value-of select="substring-before(marc:subfield[@code='a'], '(')" />
+          <xsl:value-of select="substring-before(substring-after(marc:subfield[@code='a'], '('), ')')" />
+          <xsl:value-of select="substring-after(marc:subfield[@code='a'], ')')" />
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="marc:subfield[@code='a']" />
+        </xsl:otherwise>
+      </xsl:choose> 
+<xsl:if test="marc:subfield[@code='x'][1]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][1]!=''"><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][2]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][2]!=''"><xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][3]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][3]!=''"><xsl:value-of select="marc:subfield[@code='x'][3]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='y'][1] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='y'][1] !=''"><xsl:value-of select="marc:subfield[@code='y'][1]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='y'][2] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='y'][2] !=''"><xsl:value-of select="marc:subfield[@code='y'][2]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='y'][3] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='y'][3] !=''"><xsl:value-of select="marc:subfield[@code='y'][3]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='z'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='z']!=''"><xsl:value-of select="marc:subfield[@code='z']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='j'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='j']!=''"><xsl:value-of select="marc:subfield[@code='j']"/></xsl:if>
+</xsl:attribute>
+<xsl:attribute name="title">Search on all subject words</xsl:attribute>
+<i class="fa fa-search"></i>
+</xsl:element>
+</span> 
+</xsl:for-each>
+
+
+<xsl:for-each select="marc:datafield[@tag=608]">
+<span class="results_summary">
+<span class="label">Subject - Form, physical types : </span>
+<xsl:if test="marc:subfield[@code='a']">
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='a']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='a']"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='b']">
+<xsl:text>. </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='b'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='b'][1]"/></xsl:element>
+<xsl:if test="marc:subfield[@code='b'][2]">
+<xsl:text>. </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='b'][2]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='b'][2]"/></xsl:element>
+</xsl:if>
+
+<xsl:if test="marc:subfield[@code='b'][3]">
+<xsl:text>. </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='b'][3]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='b'][3]"/></xsl:element>
+</xsl:if>
+
+       </xsl:if>
+<xsl:if test="marc:subfield[@code='c']">
+<xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+ </xsl:if>
+
+<xsl:choose>
+<xsl:when test="(marc:subfield[@code='d']) and (marc:subfield[@code='f']) and (marc:subfield[@code='e'])">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:text> ; </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='f']"/>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='d']) and (marc:subfield[@code='f'])">
+ <xsl:text> ( </xsl:text>
+</xsl:when>
+<xsl:when test="marc:subfield[@code='d']">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+</xsl:choose>
+
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='t']">
+<xsl:text> -- </xsl:text>
+<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='x']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:element>
+<xsl:if test="marc:subfield[@code='x'][2]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][2]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='x'][3]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][3]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][3]"/></xsl:element></xsl:if>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='y']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='y']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='y']"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='z']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='z']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='z']"/></xsl:element>
+</xsl:if>
+<xsl:text> | </xsl:text>
+<!-- recherche sur tous les mots -->
+<xsl:element name="a">
+<xsl:attribute name="href">/cgi-bin/koha/opac-search.pl?idx=su&amp;q=
+<xsl:choose>
+        <xsl:when test="contains(marc:subfield[@code='a'],'(')">
+          <xsl:value-of select="substring-before(marc:subfield[@code='a'], '(')" />
+          <xsl:value-of select="substring-before(substring-after(marc:subfield[@code='a'], '('), ')')" />
+          <xsl:value-of select="substring-after(marc:subfield[@code='a'], ')')" />
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="marc:subfield[@code='a']" />
+        </xsl:otherwise>
+      </xsl:choose> 
+<xsl:if test="marc:subfield[@code='b'][1]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='b'][1]!=''"><xsl:value-of select="marc:subfield[@code='b'][1]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][1]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][1]!=''"><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][2]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][2]!=''"><xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][3]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][3]!=''"><xsl:value-of select="marc:subfield[@code='x'][3]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='t']!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='t']!=''"><xsl:value-of select="marc:subfield[@code='t']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='y'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='y']!=''"><xsl:value-of select="marc:subfield[@code='y']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='z'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='z']!=''"><xsl:value-of select="marc:subfield[@code='z']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='j'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='j']!=''"><xsl:value-of select="marc:subfield[@code='j']"/></xsl:if>
+</xsl:attribute>
+<xsl:attribute name="title">Search on all subject words</xsl:attribute>
+<i class="fa fa-search"></i>
+</xsl:element>
+</span>
+</xsl:for-each>
+
+
+ <xsl:call-template name="tag_subject">
+ <xsl:with-param name="tag">615</xsl:with-param>
+ <xsl:with-param name="label">Category of subject</xsl:with-param>
+ </xsl:call-template>
+
+ <xsl:call-template name="tag_subject">
+ <xsl:with-param name="tag">616</xsl:with-param>
+ <xsl:with-param name="label">Mark</xsl:with-param>
+ </xsl:call-template>
+
+
+<xsl:if test="marc:datafield[@tag=856]/marc:subfield[@code='u']">
+<span class="results_summary">
+<span class="label">Online resource : </span>
+<xsl:for-each select="marc:datafield[@tag=856]">
+<xsl:variable name="url" select="substring-before(marc:subfield[@code='u'], '//')"/>
+<xsl:if test="contains($url,'http:') or contains($url,'https:')">
+<a>
+<xsl:attribute name="href">
+<xsl:value-of select="marc:subfield[@code='u']"/>
+</xsl:attribute>
+<xsl:choose>
+<xsl:when test="marc:subfield[@code='y' or @code='3' or @code='z']">
+<xsl:call-template name="subfieldSelect">
+<xsl:with-param name="codes">y3z</xsl:with-param>
+</xsl:call-template>
+</xsl:when>
+<xsl:when test="not(marc:subfield[@code='y']) and not(marc:subfield[@code='3']) and not(marc:subfield[@code='z'])">
+Cliquer ici
+</xsl:when>
+</xsl:choose>
+</a>
+</xsl:if>
+<xsl:if test="not(contains($url,'http:')) and not(contains($url,'https:'))">
+<a>
+<xsl:attribute name="href">
+http://<xsl:value-of select="marc:subfield[@code='u']"/>
+</xsl:attribute>
+<xsl:choose>
+<xsl:when test="marc:subfield[@code='y' or @code='3' or @code='z']">
+<xsl:call-template name="subfieldSelect">
+<xsl:with-param name="codes">y3z</xsl:with-param>
+</xsl:call-template>
+</xsl:when>
+<xsl:when test="not(marc:subfield[@code='y']) and not(marc:subfield[@code='3']) and not(marc:subfield[@code='z'])">
+Cliquer ici
+</xsl:when>
+</xsl:choose>
+</a>
+</xsl:if>
+<xsl:choose>
+<xsl:when test="position()=last()"/>
+<xsl:otherwise> | </xsl:otherwise>
+</xsl:choose>
+</xsl:for-each>
+</span>
+</xsl:if>
+
+<!--
+<xsl:if test="marc:datafield[@tag=901]">
+
+ <span class="results_summary">
+<span class="label">Type:</span>
+ <xsl:for-each select="marc:datafield[@tag=901]">
+ <xsl:for-each select="marc:subfield">
+ <xsl:value-of select="text()"/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text>.</xsl:text>
+ </xsl:when>
+ <xsl:otherwise><xsl:text>, </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+ </xsl:for-each>
+ </span>
+ </xsl:if>
+-->
+
+ <!-- 780 -->
+ <xsl:if test="marc:datafield[@tag=780]">
+ <xsl:for-each select="marc:datafield[@tag=780]">
+ <li>
+ <xsl:choose>
+ <xsl:when test="@ind2=0">
+ <strong>Continue:</strong>
+ </xsl:when>
+ <xsl:when test="@ind2=1">
+ <strong>Continue en partie:</strong>
+ </xsl:when>
+ <xsl:when test="@ind2=2">
+ <strong>Remplace :</strong>
+ </xsl:when>
+ <xsl:when test="@ind2=3">
+ <strong>Remplace partiellement :</strong>
+ </xsl:when>
+ <xsl:when test="@ind2=4">
+ <strong>Formé par la réunion de ... et: ...</strong>
+ </xsl:when>
+ <xsl:when test="@ind2=5">
+ <strong>Absorbé:</strong>
+ </xsl:when>
+ <xsl:when test="@ind2=6">
+ <strong>Absorbé en partie:</strong>
+ </xsl:when>
+ <xsl:when test="@ind2=7">
+ <strong>Séparé de :</strong>
+ </xsl:when>
+ </xsl:choose>
+
+ <xsl:variable name="f780">
+ <xsl:call-template name="subfieldSelect">
+ <xsl:with-param name="codes">à</xsl:with-param>
+ </xsl:call-template>
+ </xsl:variable>
+ <a><xsl:attribute name="href">/cgi-bin/koha/opac-search.pl?q=<xsl:value-of select="translate($f780, '()', '')"/></xsl:attribute>
+ <xsl:value-of select="translate($f780, '()', '')"/>
+ </a>
+ </li>
+
+ <xsl:choose>
+ <xsl:when test="@ind1=0">
+ <li><xsl:value-of select="marc:subfield[@code='n']"/></li>
+ </xsl:when>
+ </xsl:choose>
+
+ </xsl:for-each>
+ </xsl:if>
+
+ <!-- 785 -->
+ <xsl:if test="marc:datafield[@tag=785]">
+ <xsl:for-each select="marc:datafield[@tag=785]">
+ <li>
+ <xsl:choose>
+ <xsl:when test="@ind2=0">
+ <strong>Continué par :</strong>
+ </xsl:when>
+ <xsl:when test="@ind2=1">
+ <strong>Continué partiellement par :</strong>
+ </xsl:when>
+ <xsl:when test="@ind2=2">
+ <strong>Remplacé par :</strong>
+ </xsl:when>
+ <xsl:when test="@ind2=3">
+ <strong>Partiellement remplacé par :</strong>
+ </xsl:when>
+ <xsl:when test="@ind2=4">
+ <strong>Absorbé par:</strong>
+ </xsl:when>
+ <xsl:when test="@ind2=5">
+ <strong>Absorbé partiellement par:</strong>
+ </xsl:when>
+ <xsl:when test="@ind2=6">
+ <strong>Eclater de ... à ... :</strong>
+ </xsl:when>
+ <xsl:when test="@ind2=7">
+ <strong>Fusionné avec ... pour former ...</strong>
+ </xsl:when>
+ <xsl:when test="@ind2=8">
+ <strong>Redevient:</strong>
+ </xsl:when>
+ </xsl:choose>
+ <xsl:variable name="f785">
+ <xsl:call-template name="subfieldSelect">
+ <xsl:with-param name="codes">à</xsl:with-param>
+ </xsl:call-template>
+ </xsl:variable>
+
+ <a><xsl:attribute name="href">/cgi-bin/koha/opac-search.pl?q=<xsl:value-of select="translate($f785, '()', '')"/></xsl:attribute>
+ <xsl:value-of select="translate($f785, '()', '')"/>
+ </a>
+
+ </li>
+ </xsl:for-each>
+ </xsl:if>
+
+ </xsl:template>
+
+ <xsl:template name="nameABCDQ">
+ <xsl:call-template name="chopPunctuation">
+ <xsl:with-param name="chopString">
+ <xsl:call-template name="subfieldSelect">
+ <xsl:with-param name="codes">aq</xsl:with-param>
+ </xsl:call-template>
+ </xsl:with-param>
+ <xsl:with-param name="punctuation">
+ <xsl:text>:,;/ </xsl:text>
+ </xsl:with-param>
+ </xsl:call-template>
+ <xsl:call-template name="termsOfAddress"/>
+ </xsl:template>
+
+ <xsl:template name="nameABCDN">
+ <xsl:for-each select="marc:subfield[@code='a']">
+ <xsl:call-template name="chopPunctuation">
+ <xsl:with-param name="chopString" select="."/>
+ </xsl:call-template>
+ </xsl:for-each>
+ <xsl:for-each select="marc:subfield[@code='b']">
+ <xsl:value-of select="."/>
+ </xsl:for-each>
+ <xsl:if test="marc:subfield[@code='c'] or marc:subfield[@code='d'] or marc:subfield[@code='n']">
+ <xsl:call-template name="subfieldSelect">
+ <xsl:with-param name="codes">cdn</xsl:with-param>
+ </xsl:call-template>
+ </xsl:if>
+ </xsl:template>
+
+ <xsl:template name="nameACDEQ">
+ <xsl:call-template name="subfieldSelect">
+ <xsl:with-param name="codes">acdeq</xsl:with-param>
+ </xsl:call-template>
+ </xsl:template>
+ <xsl:template name="termsOfAddress">
+ <xsl:if test="marc:subfield[@code='b' or @code='c']">
+ <xsl:call-template name="chopPunctuation">
+ <xsl:with-param name="chopString">
+ <xsl:call-template name="subfieldSelect">
+ <xsl:with-param name="codes">bc</xsl:with-param>
+ </xsl:call-template>
+ </xsl:with-param>
+ </xsl:call-template>
+ </xsl:if>
+ </xsl:template>
+
+ <xsl:template name="part">
+ <xsl:variable name="partNumber">
+ <xsl:call-template name="specialSubfieldSelect">
+ <xsl:with-param name="axis">n</xsl:with-param>
+ <xsl:with-param name="anyCodes">n</xsl:with-param>
+ <xsl:with-param name="afterCodes">fghkdlmor</xsl:with-param>
+ </xsl:call-template>
+ </xsl:variable>
+ <xsl:variable name="partName">
+ <xsl:call-template name="specialSubfieldSelect">
+ <xsl:with-param name="axis">p</xsl:with-param>
+ <xsl:with-param name="anyCodes">p</xsl:with-param>
+ <xsl:with-param name="afterCodes">fghkdlmor</xsl:with-param>
+ </xsl:call-template>
+ </xsl:variable>
+ <xsl:if test="string-length(normalize-space($partNumber))">
+ <xsl:call-template name="chopPunctuation">
+ <xsl:with-param name="chopString" select="$partNumber"/>
+ </xsl:call-template>
+ </xsl:if>
+ <xsl:if test="string-length(normalize-space($partName))">
+ <xsl:call-template name="chopPunctuation">
+ <xsl:with-param name="chopString" select="$partName"/>
+ </xsl:call-template>
+ </xsl:if>
+ </xsl:template>
+
+ <xsl:template name="specialSubfieldSelect">
+ <xsl:param name="anyCodes"/>
+ <xsl:param name="axis"/>
+ <xsl:param name="beforeCodes"/>
+ <xsl:param name="afterCodes"/>
+ <xsl:variable name="str">
+ <xsl:for-each select="marc:subfield">
+ <xsl:if test="contains($anyCodes, @code)      or (contains($beforeCodes,@code) and following-sibling::marc:subfield[@code=$axis])      or (contains($afterCodes,@code) and preceding-sibling::marc:subfield[@code=$axis])">
+ <xsl:value-of select="text()"/>
+ <xsl:text> </xsl:text>
+ </xsl:if>
+ </xsl:for-each>
+ </xsl:variable>
+ <xsl:value-of select="substring($str,1,string-length($str)-1)"/>
+ </xsl:template>
+
+</xsl:stylesheet>

--- a/biblibre/opac/en/UNIMARCslim2OPACResults.xsl
+++ b/biblibre/opac/en/UNIMARCslim2OPACResults.xsl
@@ -1,0 +1,545 @@
+<xsl:stylesheet version="1.0"
+  xmlns:marc="http://www.loc.gov/MARC21/slim"
+  xmlns:items="http://www.koha-community.org/items"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  exclude-result-prefixes="marc items">
+
+<xsl:import href="UNIMARCslimUtils.xsl"/>
+<xsl:output method = "html" indent="yes" omit-xml-declaration = "yes" encoding="UTF-8"/>
+<xsl:key name="item-by-status" match="items:item" use="items:status"/>
+<xsl:key name="item-by-status-and-branch-home" match="items:item" use="concat(items:status, ' ', items:homebranch)"/>
+<xsl:key name="item-by-status-and-branch-holding" match="items:item" use="concat(items:status, ' ', items:holdingbranch)"/>
+
+<xsl:template match="/">
+<xsl:apply-templates/>
+</xsl:template>
+
+<xsl:template match="marc:record">
+<xsl:variable name="leader" select="marc:leader"/>
+<xsl:variable name="leader6" select="substring($leader,7,1)"/>
+<xsl:variable name="leader7" select="substring($leader,8,1)"/>
+<xsl:variable name="biblionumber" select="marc:controlfield[@tag=001]"/>
+<xsl:variable name="isbn" select="marc:datafield[@tag=010]/marc:subfield[@code='a']"/>
+<xsl:variable name="OPACResultsLibrary" select="marc:sysprefs/marc:syspref[@name='OPACResultsLibrary']"/>
+<xsl:variable name="BiblioDefaultView" select="marc:sysprefs/marc:syspref[@name='BiblioDefaultView']"/>
+<xsl:variable name="hidelostitems" select="marc:sysprefs/marc:syspref[@name='hidelostitems']"/>
+<xsl:variable name="singleBranchMode" select="marc:sysprefs/marc:syspref[@name='singleBranchMode']"/>
+<xsl:variable name="OPACURLOpenInNewWindow" select="marc:sysprefs/marc:syspref[@name='OPACURLOpenInNewWindow']"/>
+<xsl:variable name="type_doc" select="marc:datafield[@tag=099]/marc:subfield[@code='t']"/>
+
+<xsl:if test="marc:datafield[@tag=200]">
+<!--Nouveaute-->
+<xsl:call-template name="nouveaute" />
+<xsl:for-each select="marc:datafield[@tag=200]">
+<xsl:call-template name="addClassRtl" />
+<xsl:for-each select="marc:subfield">
+<xsl:choose>
+<xsl:when test="@code='a'">
+<xsl:variable name="title" select="."/>
+<xsl:variable name="ntitle"
+select="translate($title, '&#x0088;&#x0089;&#x0098;&#x009C;','')"/>
+<a>
+<xsl:attribute name="href">
+<xsl:call-template name="buildBiblioDefaultViewURL">
+<xsl:with-param name="BiblioDefaultView">
+<xsl:value-of select="$BiblioDefaultView"/>
+</xsl:with-param>
+</xsl:call-template>
+<xsl:value-of select="$biblionumber"/>
+</xsl:attribute>
+<xsl:attribute name="class">title</xsl:attribute>
+<xsl:value-of select="$ntitle" />
+</a>
+</xsl:when>
+<xsl:when test="@code='b'">
+<xsl:text> [</xsl:text>
+<xsl:value-of select="."/>
+<xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="@code='d'">
+<xsl:text> = </xsl:text>
+<xsl:value-of select="."/>
+</xsl:when>
+<xsl:when test="@code='e'">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="."/>
+</xsl:when>
+<xsl:when test="@code='f'">
+<xsl:text> / </xsl:text>
+<xsl:value-of select="."/>
+</xsl:when>
+<xsl:when test="@code='g'">
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="."/>
+</xsl:when>
+<xsl:otherwise>
+<xsl:text>, </xsl:text>
+<xsl:value-of select="."/>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:for-each>
+</xsl:for-each>
+</xsl:if>
+
+
+<xsl:if test="marc:datafield[@tag=099]/marc:subfield[@code='t']">
+  <span class="results_summary">
+    <span class="label">Category of document : </span>
+    <xsl:for-each select="marc:datafield[@tag=099]/marc:subfield[@code='t']">
+      <xsl:value-of select="."/>
+      <xsl:if test="not(position()=last())"><xsl:text> ; </xsl:text></xsl:if>
+    </xsl:for-each>
+  </span>
+</xsl:if>
+
+<!--Titre de serie - autorité 461-->
+<!--<xsl:call-template name="tag_461" />-->
+
+<!--Titre de serie non autorité 461-->
+<xsl:call-template name="tag_461bis" />
+
+<!--Titre dépouillé 463-->
+<xsl:call-template name="tag_463" />
+
+<xsl:if test="contains($type_doc,'Périodique')">
+<xsl:choose>
+<xsl:when test="$ppn">
+<xsl:call-template name="tag_462_ppn" />
+</xsl:when>
+<xsl:otherwise>
+<xsl:call-template name="tag_462" />
+</xsl:otherwise>
+</xsl:choose>
+</xsl:if>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">412</xsl:with-param>
+<xsl:with-param name="label">Is an excerpt or taken apart from</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">413</xsl:with-param>
+<xsl:with-param name="label">A for extract or pulled apart</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">421</xsl:with-param>
+<xsl:with-param name="label">Has for supplement</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">422</xsl:with-param>
+<xsl:with-param name="label">Is a supplement of</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">423</xsl:with-param>
+<xsl:with-param name="label">Is published with</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">424</xsl:with-param>
+<xsl:with-param name="label">Is updated by</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">430</xsl:with-param>
+<xsl:with-param name="label">Following</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">431</xsl:with-param>
+<xsl:with-param name="label">Succeeds after division of</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">432</xsl:with-param>
+<xsl:with-param name="label">Replace</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">433</xsl:with-param>
+<xsl:with-param name="label">Replace partially</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">434</xsl:with-param>
+<xsl:with-param name="label">Absorbed</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">435</xsl:with-param>
+<xsl:with-param name="label">Absorbed partially</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">436</xsl:with-param>
+<xsl:with-param name="label">Merge of</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">437</xsl:with-param>
+<xsl:with-param name="label">Partial sequence of</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">440</xsl:with-param>
+<xsl:with-param name="label">Become</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">441</xsl:with-param>
+<xsl:with-param name="label">Become partially</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">442</xsl:with-param>
+<xsl:with-param name="label">Replaced by</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">443</xsl:with-param>
+<xsl:with-param name="label">Remplaced partially by</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">444</xsl:with-param>
+<xsl:with-param name="label">Absorbed by</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">447</xsl:with-param>
+<xsl:with-param name="label">Meged with...to form</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">451</xsl:with-param>
+<xsl:with-param name="label">Other edition,same support</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">452</xsl:with-param>
+<xsl:with-param name="label">Other edition, different support</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">453</xsl:with-param>
+<xsl:with-param name="label">Translated under the title</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">454</xsl:with-param>
+<xsl:with-param name="label">Is a translation of</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">455</xsl:with-param>
+<xsl:with-param name="label">Is a reproduction of</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">456</xsl:with-param>
+<xsl:with-param name="label">Is reproducted as</xsl:with-param>
+</xsl:call-template>
+
+<!--<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">464</xsl:with-param>
+<xsl:with-param name="label">Composante</xsl:with-param>
+</xsl:call-template>-->
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">470</xsl:with-param>
+<xsl:with-param name="label">Analysed document</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">481</xsl:with-param>
+<xsl:with-param name="label">Is also linked in this volume</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">482</xsl:with-param>
+<xsl:with-param name="label">Linked as a result of</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">488</xsl:with-param>
+<xsl:with-param name="label">Other type of relation</xsl:with-param>
+</xsl:call-template>
+
+<xsl:if test="(marc:datafield[@tag=214] or marc:datafield[@tag=210])">
+<xsl:choose>
+<xsl:when test="(marc:datafield[@tag=214]/marc:subfield[@code='r'])">
+<xsl:call-template name="tag_214_r" />
+</xsl:when>
+<xsl:when test="(marc:datafield[@tag=214]/marc:subfield[@code='s'])">
+<xsl:call-template name="tag_214_s" />
+</xsl:when>
+<xsl:when test="(marc:datafield[@tag=210]/marc:subfield[@code='r'])">
+<xsl:call-template name="tag_210_r" />
+</xsl:when>
+<xsl:when test="(marc:datafield[@tag=210]/marc:subfield[@code='s'])">
+<xsl:call-template name="tag_210_s" />
+</xsl:when>
+<xsl:when test="(marc:datafield[@tag=214] and  marc:datafield[@tag=210])">
+<xsl:call-template name="tag_214" />
+</xsl:when>
+<xsl:when test="(marc:datafield[@tag=214])">
+<xsl:call-template name="tag_214" />
+</xsl:when>
+<xsl:when test="(marc:datafield[@tag=210])">
+<xsl:call-template name="tag_210" />
+</xsl:when>
+</xsl:choose>
+</xsl:if>
+
+<xsl:call-template name="tag_215" />
+
+<!--Collection autorité-->
+<!--
+<xsl:for-each select="marc:datafield[@tag=410]">
+<span class="results_summary">
+<span class="label">
+Collection-Authority : </span>
+<xsl:element name="a"><xsl:attribute name="href">
+/cgi-bin/koha/catalogue/search.pl?q=an:<xsl:value-of select="marc:subfield[@code='9']"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:element>
+<xsl:if test="marc:subfield[@code='t'] and marc:subfield[@code='v']">
+<xsl:text> . </xsl:text>
+<xsl:value-of select="marc:subfield[@code='v']"/>
+</xsl:if>
+</span>
+</xsl:for-each>-->
+
+
+<xsl:if test="marc:datafield[@tag=856]/marc:subfield[@code='u']"> 
+<span class="results_summary"> 
+<span class="label">Online resource : </span> 
+<xsl:for-each select="marc:datafield[@tag=856]"> 
+<xsl:variable name="url" select="substring-before(marc:subfield[@code='u'], '//')"/> 
+<xsl:if test="contains($url,'http:') or contains($url,'https:')"> 
+<a> 
+<xsl:attribute name="href"> 
+<xsl:value-of select="marc:subfield[@code='u']"/> 
+</xsl:attribute> 
+<xsl:choose> 
+<xsl:when test="marc:subfield[@code='y' or @code='3' or @code='z']"> 
+<xsl:call-template name="subfieldSelect"> 
+<xsl:with-param name="codes">y3z</xsl:with-param> 
+</xsl:call-template> 
+</xsl:when> 
+<xsl:when test="not(marc:subfield[@code='y']) and not(marc:subfield[@code='3']) and not(marc:subfield[@code='z'])"> 
+Cliquer ici 
+</xsl:when> 
+</xsl:choose> 
+</a> 
+</xsl:if> 
+<xsl:if test="not(contains($url,'http:')) and not(contains($url,'https:'))"> 
+<a> 
+<xsl:attribute name="href"> 
+http://<xsl:value-of select="marc:subfield[@code='u']"/> 
+</xsl:attribute> 
+<xsl:choose> 
+<xsl:when test="marc:subfield[@code='y' or @code='3' or @code='z']"> 
+<xsl:call-template name="subfieldSelect"> 
+<xsl:with-param name="codes">y3z</xsl:with-param> 
+</xsl:call-template> 
+</xsl:when> 
+<xsl:when test="not(marc:subfield[@code='y']) and not(marc:subfield[@code='3']) and not(marc:subfield[@code='z'])"> 
+Cliquer ici 
+</xsl:when> 
+</xsl:choose> 
+</a> 
+</xsl:if> 
+<xsl:choose> 
+<xsl:when test="position()=last()"/> 
+<xsl:otherwise> | </xsl:otherwise> 
+</xsl:choose> 
+</xsl:for-each> 
+</span> 
+</xsl:if>
+
+
+<!--Public  995q-->
+<!--<xsl:call-template name="public" />-->
+
+<!--Fonds 995h-->
+<!--<xsl:call-template name="fonds" />-->
+
+
+<xsl:if test="marc:datafield[@tag=995]">
+<span class="results_summary availability">
+<span class="label">Availability : </span>
+<xsl:choose>
+<xsl:when test="marc:datafield[@tag=1856]">
+<xsl:for-each select="marc:datafield[@tag=1856]">
+<xsl:choose>
+<xsl:when test="@ind2=0">
+<a>
+<xsl:attribute name="href">
+<xsl:value-of select="marc:subfield[@code='u']"/>
+</xsl:attribute>
+<xsl:if test="$OPACURLOpenInNewWindow='1'">
+<xsl:attribute name="target">_blank</xsl:attribute>
+</xsl:if>
+<xsl:choose>
+<xsl:when test="marc:subfield[@code='y' or code='3' or  @code='z']">
+<xsl:call-template name="subfieldSelect">
+<xsl:with-param name="codes">y3z</xsl:with-param>
+</xsl:call-template>
+</xsl:when>
+<xsl:when test="not(marc:subfield[@code='y']) and not(marc:subfield[@code='3']) and not(marc:subfield[@code='z'])">
+Click here to see the online document
+</xsl:when>
+</xsl:choose>
+</a>
+<xsl:choose>
+<xsl:when test="position()=last()"></xsl:when>
+<xsl:otherwise> | </xsl:otherwise>
+</xsl:choose>
+</xsl:when>
+</xsl:choose>
+</xsl:for-each>
+</xsl:when>
+<xsl:when test="count(key('item-by-status', 'available'))=0 and count(key('item-by-status', 'reference'))=0">
+No item available </xsl:when>
+<xsl:when test="count(key('item-by-status', 'available'))>0">
+<span class="available">
+<b><xsl:text>Item(s) onloan: </xsl:text></b>
+<xsl:variable name="available_items" select="key('item-by-status', 'available')"/>
+<xsl:choose>
+<xsl:when test="$singleBranchMode=1">
+<xsl:for-each select="$available_items[generate-id() = generate-id(key('item-by-status-and-branch-home', concat(items:status, ' ', items:homebranch))[1])]">
+<xsl:if test="items:itemcallnumber != '' and items:itemcallnumber"> [<xsl:value-of select="items:itemcallnumber"/>]</xsl:if>
+<xsl:text> (</xsl:text>
+<xsl:value-of select="count(key('item-by-status-and-branch-home', concat(items:status, ' ', items:homebranch)))"/>
+<xsl:text>)</xsl:text>
+<xsl:choose><xsl:when test="position()=last()"><xsl:text>. </xsl:text></xsl:when><xsl:otherwise><xsl:text>, </xsl:text></xsl:otherwise></xsl:choose>
+</xsl:for-each>
+</xsl:when>
+<xsl:otherwise>
+<xsl:choose>
+<xsl:when test="$OPACResultsLibrary='homebranch'">
+<xsl:for-each select="$available_items[generate-id() = generate-id(key('item-by-status-and-branch-home', concat(items:status, ' ', items:homebranch))[1])]">
+<xsl:value-of select="items:homebranch"/>
+<xsl:if test="items:itemcallnumber != '' and items:itemcallnumber">[<xsl:value-of select="items:itemcallnumber"/>]
+</xsl:if>
+<xsl:text> (</xsl:text>
+<xsl:value-of select="count(key('item-by-status-and-branch-home', concat(items:status, ' ', items:homebranch)))"/>
+<xsl:text>)</xsl:text>
+<xsl:choose>
+<xsl:when test="position()=last()">
+<xsl:text>. </xsl:text>
+</xsl:when>
+<xsl:otherwise>
+<xsl:text>, </xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:for-each>
+</xsl:when>
+<xsl:otherwise>
+<xsl:for-each select="$available_items[generate-id() = generate-id(key('item-by-status-and-branch-holding', concat(items:status, ' ', items:holdingbranch))[1])]">
+<xsl:value-of select="items:holdingbranch"/>
+<xsl:if test="items:itemcallnumber != '' and items:itemcallnumber">[<xsl:value-of select="items:itemcallnumber"/>]
+</xsl:if>
+<xsl:text> (</xsl:text>
+<xsl:value-of select="count(key('item-by-status-and-branch-holding', concat(items:status, ' ', items:holdingbranch)))"/>
+<xsl:text>)</xsl:text>
+<xsl:choose>
+<xsl:when test="position()=last()">
+<xsl:text>. </xsl:text>
+</xsl:when>
+<xsl:otherwise>
+<xsl:text>, </xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:for-each>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:otherwise>
+</xsl:choose>
+</span>
+</xsl:when>
+</xsl:choose>
+<xsl:choose>
+<xsl:when test="count(key('item-by-status', 'reference'))>0">
+<span class="unavailable">
+<b><xsl:text>Item(s) onsite :</xsl:text></b>
+<xsl:variable name="reference_items"
+select="key('item-by-status', 'reference')"/>
+<xsl:for-each select="$reference_items[generate-id() = generate-id(key('item-by-status-and-branch-home', concat(items:status, ' ', items:homebranch))[1])]">
+<xsl:if test="$singleBranchMode=0">
+<xsl:value-of select="items:homebranch"/>
+</xsl:if>
+<xsl:if test="items:itemcallnumber != '' and items:itemcallnumber">[<xsl:value-of select="items:itemcallnumber"/>]</xsl:if>
+<xsl:text> (</xsl:text>
+<xsl:value-of select="count(key('item-by-status-and-branch-home', concat(items:status, ' ', items:homebranch)))"/>
+<xsl:text>)</xsl:text>
+<xsl:choose>
+<xsl:when test="position()=last()">
+<xsl:text>. </xsl:text>
+</xsl:when>
+<xsl:otherwise>
+<xsl:text>, </xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:for-each>
+</span>
+</xsl:when>
+</xsl:choose>
+<xsl:if test="count(key('item-by-status', 'Checked out'))>0">
+<span class="unavailable">
+<xsl:text> Onloan (</xsl:text>
+<xsl:value-of select="count(key('item-by-status', 'Checked out'))"/>
+<xsl:text>). </xsl:text>
+</span>
+</xsl:if>
+<xsl:if test="count(key('item-by-status', 'Withdrawn'))>0">
+<span class="unavailable">
+<xsl:text> Withdrawn (</xsl:text>
+<xsl:value-of select="count(key('item-by-status', 'Withdrawn'))"/>
+<xsl:text>). </xsl:text>
+</span>
+</xsl:if>
+<xsl:if test="$hidelostitems='0' and count(key('item-by-status', 'Lost'))>0">
+<span class="unavailable">
+<xsl:text> Lost (</xsl:text>
+<xsl:value-of select="count(key('item-by-status', 'Lost'))"/>
+<xsl:text>). </xsl:text>
+</span>
+</xsl:if>
+<xsl:if test="count(key('item-by-status', 'Damaged'))>0">
+<span class="unavailable">
+<xsl:text> Damaged (</xsl:text>
+<xsl:value-of select="count(key('item-by-status', 'Damaged'))"/>
+<xsl:text>). </xsl:text>
+</span>
+</xsl:if>
+<xsl:if test="count(key('item-by-status', 'On order'))>0">
+<span class="unavailable">
+<xsl:text> In order (</xsl:text>
+<xsl:value-of select="count(key('item-by-status', 'On order'))"/>
+<xsl:text>). </xsl:text>
+</span>
+</xsl:if>
+<xsl:if test="count(key('item-by-status', 'In transit'))>0">
+<span class="unavailable">
+<xsl:text> In Transit (</xsl:text>
+<xsl:value-of select="count(key('item-by-status', 'In transit'))"/>
+<xsl:text>). </xsl:text>
+</span>
+</xsl:if>
+<xsl:if test="count(key('item-by-status', 'Waiting'))>0">
+<span class="unavailable">
+<xsl:text> Hold (</xsl:text>
+<xsl:value-of select="count(key('item-by-status', 'Waiting'))"/>
+<xsl:text>). </xsl:text>
+</span>
+</xsl:if>
+</span>
+</xsl:if>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/biblibre/opac/en/UNIMARCslimUtils.xsl
+++ b/biblibre/opac/en/UNIMARCslimUtils.xsl
@@ -1,0 +1,1563 @@
+<xsl:stylesheet version="1.0"
+  xmlns:marc="http://www.loc.gov/MARC21/slim"
+  xmlns:items="http://www.koha-community.org/items"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  exclude-result-prefixes="marc items">
+
+ <xsl:template name="datafield">
+ <xsl:param name="tag"/>
+ <xsl:param name="ind1"><xsl:text> </xsl:text></xsl:param>
+ <xsl:param name="ind2"><xsl:text> </xsl:text></xsl:param>
+ <xsl:param name="subfields"/>
+ <xsl:element name="datafield">
+ <xsl:attribute name="tag">
+ <xsl:value-of select="$tag"/>
+ </xsl:attribute>
+ <xsl:attribute name="ind1">
+ <xsl:value-of select="$ind1"/>
+ </xsl:attribute>
+ <xsl:attribute name="ind2">
+ <xsl:value-of select="$ind2"/>
+ </xsl:attribute>
+ <xsl:copy-of select="$subfields"/>
+ </xsl:element>
+ </xsl:template>
+
+ <xsl:template name="subfieldSelect">
+ <xsl:param name="codes"/>
+ <xsl:param name="delimeter"><xsl:text> </xsl:text></xsl:param>
+ <xsl:param name="subdivCodes"/>
+ <xsl:param name="subdivDelimiter"/>
+ <xsl:variable name="str">
+ <xsl:for-each select="marc:subfield">
+ <xsl:if test="contains($codes, @code)">
+ <xsl:if test="contains($subdivCodes, @code)">
+ <xsl:value-of select="$subdivDelimiter"/>
+ </xsl:if>
+ <xsl:value-of select="text()"/><xsl:value-of select="$delimeter"/>
+ </xsl:if>
+ </xsl:for-each>
+ </xsl:variable>
+ <xsl:value-of select="substring($str,1,string-length($str)-string-length($delimeter))"/>
+ </xsl:template>
+
+ <xsl:template name="buildSpaces">
+ <xsl:param name="spaces"/>
+ <xsl:param name="char"><xsl:text> </xsl:text></xsl:param>
+ <xsl:if test="$spaces>0">
+ <xsl:value-of select="$char"/>
+ <xsl:call-template name="buildSpaces">
+ <xsl:with-param name="spaces" select="$spaces - 1"/>
+ <xsl:with-param name="char" select="$char"/>
+ </xsl:call-template>
+ </xsl:if>
+ </xsl:template>
+
+ <xsl:template name="buildBiblioDefaultViewURL">
+ <xsl:param name="BiblioDefaultView"/>
+ <xsl:choose>
+ <xsl:when test="$BiblioDefaultView='normal'">
+ <xsl:text>/cgi-bin/koha/opac-detail.pl?biblionumber=</xsl:text>
+ </xsl:when>
+ <xsl:when test="$BiblioDefaultView='isbd'">
+ <xsl:text>/cgi-bin/koha/opac-ISBDdetail.pl?biblionumber=</xsl:text>
+ </xsl:when>
+ <xsl:when test="$BiblioDefaultView='marc'">
+ <xsl:text>/cgi-bin/koha/opac-MARCdetail.pl?biblionumber=</xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text>/cgi-bin/koha/opac-detail.pl?biblionumber=</xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:template>
+
+
+ <xsl:template name="chopPunctuation">
+ <xsl:param name="chopString"/>
+ <xsl:variable name="length" select="string-length($chopString)"/>
+ <xsl:choose>
+ <xsl:when test="$length=0"/>
+ <xsl:when test="contains('.:,;/ ', substring($chopString,$length,1))">
+ <xsl:call-template name="chopPunctuation">
+ <xsl:with-param name="chopString" select="substring($chopString,1,$length - 1)"/>
+ </xsl:call-template>
+ </xsl:when>
+ <xsl:when test="not($chopString)"/>
+ <xsl:otherwise><xsl:value-of select="$chopString"/></xsl:otherwise>
+ </xsl:choose>
+ <xsl:text> </xsl:text>
+ </xsl:template>
+
+ <xsl:template name="addClassRtl">
+ <xsl:variable name="lang" select="marc:subfield[@code='7']" />
+ <xsl:if test="$lang = 'ha' or $lang = 'Hebrew' or $lang = 'fa' or $lang = 'Arabe'">
+ <xsl:attribute name="class">rtl</xsl:attribute>
+ </xsl:if>
+ </xsl:template>
+
+ <xsl:template name="tag_title">
+ <xsl:param name="tag" />
+ <xsl:param name="label" />
+ <xsl:param name="spanclass" />
+ <xsl:if test="marc:datafield[@tag=$tag]">
+ <span class="results_summary">
+ <span class="label">
+ <xsl:value-of select="$label"/>: </span>
+ <xsl:for-each select="marc:datafield[@tag=$tag]">
+ <xsl:call-template name="addClassRtl" />
+ <xsl:for-each select="marc:subfield">
+ <xsl:choose>
+ <xsl:when test="@code='a'">
+ <xsl:variable name="title" select="."/>
+ <xsl:variable name="ntitle"
+ select="translate($title, '&#x0088;&#x0089;&#x0098;&#x009C;','')"/>
+ <xsl:value-of select="$ntitle" />
+ </xsl:when>
+ <xsl:when test="@code='b'">
+ <xsl:text>[</xsl:text>
+ <xsl:value-of select="."/>
+ <xsl:text>]</xsl:text>
+ </xsl:when>
+ <xsl:when test="@code='d'">
+ <xsl:text> = </xsl:text>
+ <xsl:value-of select="."/>
+ </xsl:when>
+ <xsl:when test="@code='e'">
+ <xsl:text> : </xsl:text>
+ <xsl:value-of select="."/>
+ </xsl:when>
+ <xsl:when test="@code='f'">
+ <xsl:text> / </xsl:text>
+ <xsl:value-of select="."/>
+ </xsl:when>
+ <xsl:when test="@code='g'">
+ <xsl:text> ; </xsl:text>
+ <xsl:value-of select="."/>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:if test="position()>1">
+ <xsl:text>, </xsl:text>
+ </xsl:if>
+ <xsl:value-of select="."/>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+ <xsl:if test="not (position() = last())">
+ <xsl:text> • </xsl:text>
+ </xsl:if>
+ </xsl:for-each>
+ </span>
+ </xsl:if>
+ </xsl:template>
+
+ <xsl:template name="tag_comma">
+ <xsl:param name="tag" />
+ <xsl:param name="label" />
+ <xsl:param name="spanclass" />
+ <xsl:if test="marc:datafield[@tag=$tag]">
+ <span class="results_summary {$spanclass}">
+ <span class="label">
+ <xsl:value-of select="$label"/>: </span>
+ <xsl:for-each select="marc:datafield[@tag=$tag]">
+ <xsl:call-template name="addClassRtl" />
+ <xsl:for-each select="marc:subfield">
+ <xsl:if test="position()>1">
+ <xsl:text>, </xsl:text>
+ </xsl:if>
+ <xsl:value-of select="."/>
+ </xsl:for-each>
+ <xsl:if test="not (position() = last())">
+ <xsl:text> • </xsl:text>
+ </xsl:if>
+ </xsl:for-each>
+ </span>
+ </xsl:if>
+ </xsl:template>
+
+  <xsl:template name="tag_210">
+<xsl:for-each select="marc:datafield[@tag=210]">
+<span class="results_summary">
+<span class="label">Publication : </span>
+<xsl:choose>
+<xsl:when test="(marc:subfield[@code='a'][2]) and (marc:subfield[@code='c'][2]) and (marc:subfield[@code='d'])">
+<xsl:value-of select="marc:subfield[@code='a'][1]"/>
+<xsl:text> : </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Publisher&amp;q=
+<xsl:value-of select="marc:subfield[@code='c'][1]"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c'][1]"/>
+</xsl:element>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='a'][2]"/>
+<xsl:text> : </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Publisher&amp;q=
+<xsl:value-of select="marc:subfield[@code='c'][2]"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c'][2]"/>
+</xsl:element>
+<xsl:if test="marc:subfield[@code='a'][3]">
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='a'][3]"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='c'][3]">
+<xsl:text> : </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Publisher&amp;q=
+<xsl:value-of select="marc:subfield[@code='c'][3]"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c'][3]"/>
+</xsl:element>
+</xsl:if>
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='c'][2]) and (marc:subfield[@code='d'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:if test="position()!=last()">
+<xsl:text> ; </xsl:text>
+</xsl:if>
+<xsl:if test="position()=last()">
+<xsl:text> : </xsl:text>
+</xsl:if>
+<xsl:for-each select="marc:subfield[@code='c']">
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Publisher&amp;q=
+<xsl:value-of select="text()"/>
+</xsl:attribute>
+<xsl:value-of select="text()"/>
+</xsl:element>
+<xsl:if test="position()!=last()">
+<xsl:text> : </xsl:text>
+</xsl:if>
+<xsl:if test="position()=last()">
+<xsl:text></xsl:text>
+</xsl:if>
+</xsl:for-each>
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a'][2]) and (marc:subfield[@code='c']) and (marc:subfield[@code='d'])">
+<xsl:for-each select="marc:subfield[@code='a']">
+<xsl:value-of select="text()"/>
+<xsl:if test="position()!=last()">
+<xsl:text> ; </xsl:text>
+</xsl:if>
+<xsl:if test="position()=last()">
+<xsl:text> : </xsl:text>
+</xsl:if>
+</xsl:for-each>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Publisher&amp;q=
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:element>
+<xsl:if test="position()!=last()">
+<xsl:text> : </xsl:text>
+</xsl:if>
+<xsl:if test="position()=last()">
+<xsl:text></xsl:text>
+</xsl:if>
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='c']) and (marc:subfield[@code='d'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text> : </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Publisher&amp;q=
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:element>
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='c'][2])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text> : </xsl:text>
+<xsl:for-each select="marc:subfield[@code='c']">
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Publisher&amp;q=
+<xsl:value-of select="text()"/>
+</xsl:attribute>
+<xsl:value-of select="text()"/>
+</xsl:element>
+<xsl:if test="position()!=last()">
+<xsl:text> : </xsl:text>
+</xsl:if>
+<xsl:if test="position()=last()">
+<xsl:text></xsl:text>
+</xsl:if>
+</xsl:for-each>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='c'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text> : </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Publisher&amp;q=
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:element>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='c'][2]) and (marc:subfield[@code='d'])">
+<xsl:for-each select="marc:subfield[@code='c']">
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Publisher&amp;q=
+<xsl:value-of select="text()"/>
+</xsl:attribute>
+<xsl:value-of select="text()"/>
+</xsl:element>
+<xsl:if test="position()!=last()">
+<xsl:text> : </xsl:text>
+</xsl:if>
+<xsl:if test="position()=last()">
+<xsl:text>, </xsl:text>
+</xsl:if>
+</xsl:for-each>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='c']) and (marc:subfield[@code='d'])">
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Publisher&amp;q=
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:element>
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a'][2]) and (marc:subfield[@code='d'])">
+<xsl:for-each select="marc:subfield[@code='a']">
+<xsl:value-of select="text()"/>
+<xsl:if test="position()!=last()">
+<xsl:text> ; </xsl:text>
+</xsl:if>
+<xsl:if test="position()=last()">
+<xsl:text>, </xsl:text>
+</xsl:if>
+</xsl:for-each>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='d'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='c'])">
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Publisher&amp;q=
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:element>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='d'])">
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='e'])">
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='h']">
+<xsl:text> , </xsl:text>
+<xsl:value-of select="marc:subfield[@code='h']"/>
+</xsl:if>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='g'])">
+<xsl:value-of select="marc:subfield[@code='g']"/>
+<xsl:if test="marc:subfield[@code='h']">
+<xsl:text> , </xsl:text>
+<xsl:value-of select="marc:subfield[@code='h']"/>
+</xsl:if>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='h'])">
+<xsl:value-of select="marc:subfield[@code='h']"/>
+</xsl:when>
+</xsl:choose>
+</span>
+</xsl:for-each>
+ </xsl:template>
+
+
+ <xsl:template name="tag_214">
+<xsl:for-each select="marc:datafield[@tag=214]">
+<span class="results_summary">
+<span class="label">Publication : </span>
+<xsl:choose>
+<xsl:when test="(marc:subfield[@code='a'][2]) and (marc:subfield[@code='c'][2]) and (marc:subfield[@code='d'])">
+<xsl:value-of select="marc:subfield[@code='a'][1]"/>
+<xsl:text> : </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Publisher&amp;q=
+<xsl:value-of select="marc:subfield[@code='c'][1]"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c'][1]"/>
+</xsl:element>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='a'][2]"/>
+<xsl:text> : </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Publisher&amp;q=
+<xsl:value-of select="marc:subfield[@code='c'][2]"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c'][2]"/>
+</xsl:element>
+<xsl:if test="marc:subfield[@code='a'][3]">
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='a'][3]"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='c'][3]">
+<xsl:text> : </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Publisher&amp;q=
+<xsl:value-of select="marc:subfield[@code='c'][3]"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c'][3]"/>
+</xsl:element>
+</xsl:if>
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='c'][2]) and (marc:subfield[@code='d'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:if test="position()!=last()">
+<xsl:text> ; </xsl:text>
+</xsl:if>
+<xsl:if test="position()=last()">
+<xsl:text> : </xsl:text>
+</xsl:if>
+<xsl:for-each select="marc:subfield[@code='c']">
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Publisher&amp;q=
+<xsl:value-of select="text()"/>
+</xsl:attribute>
+<xsl:value-of select="text()"/>
+</xsl:element>
+<xsl:if test="position()!=last()">
+<xsl:text> : </xsl:text>
+</xsl:if>
+<xsl:if test="position()=last()">
+<xsl:text></xsl:text>
+</xsl:if>
+</xsl:for-each>
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a'][2]) and (marc:subfield[@code='c']) and (marc:subfield[@code='d'])">
+<xsl:for-each select="marc:subfield[@code='a']">
+<xsl:value-of select="text()"/>
+<xsl:if test="position()!=last()">
+<xsl:text> ; </xsl:text>
+</xsl:if>
+<xsl:if test="position()=last()">
+<xsl:text> : </xsl:text>
+</xsl:if>
+</xsl:for-each>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Publisher&amp;q=
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:element>
+<xsl:if test="position()!=last()">
+<xsl:text> : </xsl:text>
+</xsl:if>
+<xsl:if test="position()=last()">
+<xsl:text></xsl:text>
+</xsl:if>
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='c']) and (marc:subfield[@code='d'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text> : </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Publisher&amp;q=
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:element>
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='c'][2])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text> : </xsl:text>
+<xsl:for-each select="marc:subfield[@code='c']">
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Publisher&amp;q=
+<xsl:value-of select="text()"/>
+</xsl:attribute>
+<xsl:value-of select="text()"/>
+</xsl:element>
+<xsl:if test="position()!=last()">
+<xsl:text> : </xsl:text>
+</xsl:if>
+<xsl:if test="position()=last()">
+<xsl:text></xsl:text>
+</xsl:if>
+</xsl:for-each>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='c'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text> : </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Publisher&amp;q=
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:element>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='c'][2]) and (marc:subfield[@code='d'])">
+<xsl:for-each select="marc:subfield[@code='c']">
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Publisher&amp;q=
+<xsl:value-of select="text()"/>
+</xsl:attribute>
+<xsl:value-of select="text()"/>
+</xsl:element>
+<xsl:if test="position()!=last()">
+<xsl:text> : </xsl:text>
+</xsl:if>
+<xsl:if test="position()=last()">
+<xsl:text>, </xsl:text>
+</xsl:if>
+</xsl:for-each>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='c']) and (marc:subfield[@code='d'])">
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Publisher&amp;q=
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:element>
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a'][2]) and (marc:subfield[@code='d'])">
+<xsl:for-each select="marc:subfield[@code='a']">
+<xsl:value-of select="text()"/>
+<xsl:if test="position()!=last()">
+<xsl:text> ; </xsl:text>
+</xsl:if>
+<xsl:if test="position()=last()">
+<xsl:text>, </xsl:text>
+</xsl:if>
+</xsl:for-each>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='d'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+
+<xsl:when test="(marc:subfield[@code='c'])">
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Publisher&amp;q=
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:element>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='d'])">
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='e'])">
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='h']">
+<xsl:text> , </xsl:text>
+<xsl:value-of select="marc:subfield[@code='h']"/>
+</xsl:if>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='g'])">
+<xsl:value-of select="marc:subfield[@code='g']"/>
+<xsl:if test="marc:subfield[@code='h']">
+<xsl:text> , </xsl:text>
+<xsl:value-of select="marc:subfield[@code='h']"/>
+</xsl:if>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='h'])">
+<xsl:value-of select="marc:subfield[@code='h']"/>
+</xsl:when>
+</xsl:choose>
+</span>
+</xsl:for-each>
+ </xsl:template>
+
+<!--210$s et $r Colophon et adresse transcrite-->
+<xsl:template name="tag_210_s">
+<xsl:if test="marc:datafield[@tag=210]/marc:subfield[@code='s']">
+<span class="results_summary">
+<span class="label">Colophon : </span>
+<xsl:for-each select="marc:datafield[@tag=210]">
+<xsl:value-of select="marc:subfield[@code='s']"/>
+<xsl:choose>
+<xsl:when test="position()=last()">
+<xsl:text>.</xsl:text>
+</xsl:when>
+<xsl:otherwise><xsl:text>, </xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:for-each>
+</span>
+</xsl:if>
+</xsl:template>
+
+<xsl:template name="tag_210_r">
+<xsl:if test="marc:datafield[@tag=210]/marc:subfield[@code='r']">
+<span class="results_summary">
+<span class="label">Adresse transcrite : </span>
+<xsl:for-each select="marc:datafield[@tag=210]">
+<xsl:value-of select="marc:subfield[@code='r']"/>
+<xsl:choose>
+<xsl:when test="position()=last()">
+<xsl:text>.</xsl:text>
+</xsl:when>
+<xsl:otherwise><xsl:text>, </xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:for-each>
+</span>
+</xsl:if>
+</xsl:template>
+
+<!--TB-214$s et $r Colophon et adresse transcrite-->
+<xsl:template name="tag_214_s">
+<xsl:if test="marc:datafield[@tag=214]/marc:subfield[@code='s']">
+<span class="results_summary">
+<span class="label">Colophon : </span>
+<xsl:for-each select="marc:datafield[@tag=214]">
+<xsl:value-of select="marc:subfield[@code='s']"/>
+<xsl:choose>
+<xsl:when test="position()=last()">
+<xsl:text>.</xsl:text>
+</xsl:when>
+<xsl:otherwise><xsl:text>, </xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:for-each>
+</span>
+</xsl:if>
+</xsl:template>
+
+<xsl:template name="tag_214_r">
+<xsl:if test="marc:datafield[@tag=214]/marc:subfield[@code='r']">
+<span class="results_summary">
+<span class="label">Address : </span>
+<xsl:for-each select="marc:datafield[@tag=210]">
+<xsl:value-of select="marc:subfield[@code='r']"/>
+<xsl:choose>
+<xsl:when test="position()=last()">
+<xsl:text>.</xsl:text>
+</xsl:when>
+<xsl:otherwise><xsl:text>, </xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:for-each>
+</span>
+</xsl:if>
+</xsl:template>
+
+
+
+
+ <xsl:template name="tag_215">
+ <xsl:for-each select="marc:datafield[@tag=215]">
+ <span class="results_summary">
+ <span class="label">Description : </span>
+<xsl:choose>
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='c']) and (marc:subfield[@code='d']) and (marc:subfield[@code='e'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:text> + </xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='c']) and (marc:subfield[@code='d'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='e']) and (marc:subfield[@code='d'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:text> + </xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='e']) and (marc:subfield[@code='c'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+<xsl:text> + </xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='c'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='d'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='e'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text> + </xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='a'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='c'])">
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='d'])">
+<xsl:value-of select="marc:subfield[@code='d']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='e'])">
+<xsl:value-of select="marc:subfield[@code='e']"/>
+</xsl:when>
+</xsl:choose>
+ </span>
+ </xsl:for-each>
+ </xsl:template>
+
+<!--Titre de serie - autorité 461-->
+<xsl:template name="tag_461">
+<xsl:for-each select="marc:datafield[@tag=461]">
+<span class="results_summary">
+<span class="label">Title of serie : </span>
+<xsl:call-template name="addClassRtl" />
+<xsl:choose>
+<xsl:when test="marc:subfield[@code='9']">
+<xsl:element name="a"><xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?q=an:<xsl:value-of select="marc:subfield[@code='9']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='t']"/></xsl:element>
+</xsl:when>
+<xsl:otherwise>
+<xsl:element name="a"><xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=index-title-serie,phr&amp;q=<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='t']"/></xsl:element>
+</xsl:otherwise>
+</xsl:choose>
+<xsl:if test="marc:subfield[@code='e']"> :
+<xsl:value-of select="marc:subfield[@code='e']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='f']"> /
+<xsl:value-of select="marc:subfield[@code='f']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='d']"> ,
+<xsl:value-of select="marc:subfield[@code='d']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='p']"> ,
+<xsl:value-of select="marc:subfield[@code='p']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='v']">,
+<xsl:value-of select="marc:subfield[@code='v']"/>
+</xsl:if>
+</span>
+</xsl:for-each>
+</xsl:template>
+
+
+<!--Titre de serie non autorité 461-->
+<xsl:template name="tag_461bis">
+<xsl:variable name="type_doc" select="marc:datafield[@tag=099]/marc:subfield[@code='t']"/>
+<xsl:for-each select="marc:datafield[@tag=461]">
+<xsl:call-template name="addClassRtl" />
+<xsl:choose>
+<!--si notice d'article-->
+<xsl:when test="contains($type_doc,'Article') and marc:subfield[@code='9']">
+<li style="list-style-type: none;">
+<strong>Title of journal : </strong>
+<xsl:if test="marc:subfield[@code='a']">
+<xsl:value-of select="marc:subfield[@code='a']"/><xsl:text> , </xsl:text>
+</xsl:if>
+<xsl:element name="a"><xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=sn&amp;q=<xsl:value-of select="marc:subfield[@code='9']
+"/>
+</xsl:attribute> <xsl:value-of select="marc:subfield[@code='t']"/></xsl:element>
+<xsl:element name="a"><xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=index-title-serie,phr&amp;q=<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:attribute> - Voir les autres articles</xsl:element>
+</li>
+</xsl:when>
+<!--sinon-->
+<xsl:otherwise>
+<li style="list-style-type: none;">
+<strong>Title of serie : </strong>
+<xsl:if test="marc:subfield[@code='a']">
+<xsl:value-of select="marc:subfield[@code='a']"/><xsl:text> , </xsl:text>
+</xsl:if>
+<xsl:element name="a"><xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=index-title-serie,phr&amp;q=<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:attribute> <xsl:value-of select="marc:subfield[@code='t']"/></xsl:element>
+</li>
+</xsl:otherwise>
+</xsl:choose>
+<xsl:if test="marc:datafield[@tag=461]/marc:subfield[@code='e']"> :
+<xsl:value-of select="marc:datafield[@tag=461]/marc:subfield[@code='e']"/>
+</xsl:if>
+<xsl:if test="marc:datafield[@tag=461]/marc:subfield[@code='f']"> /
+<xsl:value-of select="marc:datafield[@tag=461]/marc:subfield[@code='f']"/>
+</xsl:if>
+<xsl:if test="marc:datafield[@tag=461]/marc:subfield[@code='d']"> ,
+<xsl:value-of select="marc:datafield[@tag=461]/marc:subfield[@code='d']"/>
+</xsl:if>
+<xsl:if test="marc:datafield[@tag=461]/marc:subfield[@code='p']"> ,
+<xsl:value-of select="marc:datafield[@tag=461]/marc:subfield[@code='p']"/>
+</xsl:if>
+<xsl:if test="marc:datafield[@tag=461]/marc:subfield[@code='v']">,
+<xsl:value-of select="marc:datafield[@tag=461]/marc:subfield[@code='v']"/>
+</xsl:if>
+<xsl:if test="marc:datafield[@tag=461]/marc:subfield[@code='w']"> -
+<xsl:value-of select="marc:datafield[@tag=461]/marc:subfield[@code='w']"/>
+</xsl:if>
+</xsl:for-each>	
+</xsl:template>
+
+<!--Titre dépouillé 463-->
+<xsl:template name="tag_463">
+<xsl:for-each select="marc:datafield[@tag=463][1]">
+<span class="results_summary">
+<span class="label">Title magazine : </span>
+<xsl:call-template name="addClassRtl" />
+<xsl:if test="marc:subfield[@code='a']">
+<xsl:value-of select="marc:subfield[@code='a']"/><xsl:text>. </xsl:text>
+</xsl:if>
+<xsl:choose>
+<xsl:when test="marc:subfield[@code='9']">
+<xsl:element name="a"><xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Local-number,phr&amp;q=<xsl:value-of select="marc:subfield[@code='9']"/>
+</xsl:attribute> <xsl:value-of select="marc:subfield[@code='t']"/></xsl:element>
+</xsl:when>
+<xsl:otherwise>
+<xsl:element name="a"><xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=index-title-article,phr&amp;q=<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:attribute> <xsl:value-of select="marc:subfield[@code='t']"/></xsl:element>
+</xsl:otherwise>
+</xsl:choose>
+<xsl:if test="marc:subfield[@code='e']"> :
+<xsl:value-of select="marc:subfield[@code='e']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='f']"> /
+<xsl:value-of select="marc:subfield[@code='f']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='d']"> ,
+<xsl:value-of select="marc:subfield[@code='d']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='p']"> ,
+<xsl:value-of select="marc:subfield[@code='p']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='v']">,
+<xsl:value-of select="marc:subfield[@code='v']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='w']"> -
+<xsl:value-of select="marc:subfield[@code='w']"/>
+</xsl:if>
+</span>
+</xsl:for-each>
+</xsl:template>
+
+<!--Public 995q-->
+<xsl:template name="public">
+<xsl:if test="marc:datafield[@tag=995]/marc:subfield[@code='q']">
+<span class="results_summary">
+<span class="label">Public :</span>
+<xsl:for-each select="marc:datafield[@tag=995]/marc:subfield[@code='q']">
+<xsl:if test="position() = 1">
+<xsl:value-of select="." />
+</xsl:if></xsl:for-each>
+</span> 
+</xsl:if>
+</xsl:template>
+
+<!--Fonds 995h-->
+<xsl:template name="fonds">
+<xsl:if test="marc:datafield[@tag=995]/marc:subfield[@code='h']">
+<span class="results_summary">
+<span class="label">Fonds : </span>
+<xsl:for-each select="marc:datafield[@tag=995]/marc:subfield[@code='h']">
+<xsl:if test="position() = 1">
+<xsl:value-of select="." />
+</xsl:if></xsl:for-each>
+</span>
+</xsl:if>
+</xsl:template>
+
+<!--Nouveauté 995$B-->
+<xsl:template name="nouveaute">
+<xsl:if test="marc:datafield[@tag=995]/marc:subfield[@code='B']">
+<xsl:for-each select="marc:datafield[@tag=995]/marc:subfield[@code='B']">
+<xsl:if test="position() = 1">
+<xsl:element name="img">
+<xsl:attribute name="size">14px</xsl:attribute>
+<xsl:attribute name="src">/public/images/nouveau.png</xsl:attribute><xsl:attribute name="title">New</xsl:attribute></xsl:element>
+</xsl:if></xsl:for-each>
+</xsl:if>
+</xsl:template>
+
+<xsl:template name="tag_462_ppn">
+<xsl:variable name="ppn" select="marc:controlfield[@tag=009]"/>
+<xsl:for-each select="marc:controlfield[@tag=009]">
+<span class="results_summary">
+<span class="label">Articles </span>
+
+<xsl:call-template name="addClassRtl" />
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=kw,phr&amp;q=<xsl:value-of select="$ppn"/>
+</xsl:attribute>See title</xsl:element>
+</span>
+</xsl:for-each>
+</xsl:template>
+
+
+<xsl:template name="tag_462">
+<xsl:for-each select="marc:datafield[@tag=090][1]">
+<span class="results_summary">
+<span class="label">Articles : </span>
+<xsl:call-template name="addClassRtl" />
+<xsl:if test="marc:subfield[@code='a']">
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=index-lien-desc,phr&amp;q=<xsl:value-of select="marc:subfield[@code='a'][1]"/>
+</xsl:attribute>See title</xsl:element>
+</xsl:if>
+</span>
+</xsl:for-each>
+</xsl:template>
+
+<xsl:template name="tag_4xx">
+<xsl:param name="tag" />
+<xsl:param name="label" />
+<xsl:if test="marc:datafield[@tag=$tag]">
+<span class="results_summary">
+<span class="label"><xsl:value-of select="$label" /> : </span>
+<xsl:for-each select="marc:datafield[@tag=$tag]">
+<xsl:call-template name="addClassRtl" />
+<xsl:choose>
+<xsl:when test="marc:subfield[@code='9']">
+<xsl:element name="a"><xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Local-number,phr&amp;q=<xsl:value-of select="marc:subfield[@code='9']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='t']"/></xsl:element>
+</xsl:when>
+<xsl:when test="marc:subfield[@code='0']">
+<xsl:element name="a"><xsl:attribute name="href">
+/cgi-bin/koha/catalogue/search.pl?idx=kw,phr&amp;q=<xsl:value-of select="marc:subfield[@code='0']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='t']"/></xsl:element>
+</xsl:when>
+<xsl:otherwise>
+<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:otherwise>
+</xsl:choose>
+<xsl:if test="marc:subfield[@code='c']"> : <xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='d']"> ; <xsl:value-of select="marc:subfield[@code='d']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='e'][1]"> - <xsl:value-of select="marc:subfield[@code='e'][1]"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='f'][1]"> - <xsl:value-of select="marc:subfield[@code='f'][1]"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='g'][1]"> - <xsl:value-of select="marc:subfield[@code='g'][1]"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='h'][1]"> - <xsl:value-of select="marc:subfield[@code='h'][1]"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='i'][1]"> - <xsl:value-of select="marc:subfield[@code='i'][1]"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='l'][1]"> - <xsl:value-of select="marc:subfield[@code='l'][1]"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='v'][1]"> , <xsl:value-of select="marc:subfield[@code='v'][1]"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='x']">,
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=ns&amp;q=<xsl:value-of select="marc:subfield[@code='x'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='y']">,
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=nb&amp;q=<xsl:value-of select="marc:subfield[@code='y'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='y'][1]"/></xsl:element>
+</xsl:if>
+<xsl:if test="not (position() = last())">
+<xsl:text> ; </xsl:text>
+</xsl:if>
+</xsl:for-each>
+</span>
+</xsl:if>
+</xsl:template>
+
+ <xsl:template name="tag_onesubject">
+ <xsl:choose>
+ <xsl:when test="marc:subfield[@code=9]">
+ <xsl:for-each select="marc:subfield">
+ <xsl:if test="@code='9'">
+ <xsl:variable name="start" select="position()"/>
+ <xsl:variable name="ends">
+ <xsl:for-each select="../marc:subfield[position() &gt; $start]">
+ <xsl:if test="@code=9">
+ <xsl:variable name="end" select="position() + $start"/>
+ <xsl:value-of select="$end"/>
+ <xsl:text>,</xsl:text>
+ </xsl:if>
+ </xsl:for-each>
+ </xsl:variable>
+ <xsl:variable name="end">
+ <xsl:choose>
+ <xsl:when test="string-length($ends) > 0">
+ <xsl:value-of select="substring-before($ends,',')"/>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text>1000</xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:variable>
+ <xsl:variable name="display">
+ <xsl:for-each select="../marc:subfield[position() &gt; $start and position() &lt; $end and @code!=2 and @code!=3]">
+ <xsl:value-of select="."/>
+ <xsl:if test="not(position()=last())">
+ <xsl:text>, </xsl:text>
+ </xsl:if>
+ </xsl:for-each>
+ </xsl:variable>
+ <a>
+ <xsl:attribute name="href">
+ <xsl:text>/cgi-bin/koha/opac-search.pl?q=an:</xsl:text>
+ <xsl:value-of select="."/>
+ </xsl:attribute>
+ <xsl:choose>
+ <xsl:when test="string-length($display) &gt; 0">
+ <xsl:call-template name="chopPunctuation">
+ <xsl:with-param name="chopString">
+ <xsl:value-of select="$display"/>
+ </xsl:with-param>
+ </xsl:call-template>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:value-of select="."/>
+ </xsl:otherwise>
+ </xsl:choose>
+ </a>
+ <xsl:variable name="ncommas"
+ select="string-length($ends) - string-length(translate($ends, ',', ''))" />
+ <xsl:if test="$ncommas &gt; 1">
+ <xsl:text> -- </xsl:text>
+ </xsl:if>
+ </xsl:if>
+ </xsl:for-each>
+ </xsl:when>
+ <xsl:when test="marc:subfield[@code='a']">
+ <a>
+ <xsl:attribute name="href">
+ <xsl:text>/cgi-bin/koha/opac-search.pl?q=su:</xsl:text>
+ <xsl:value-of select="marc:subfield[@code='a']"/>
+ </xsl:attribute>
+ <xsl:call-template name="chopPunctuation">
+ <xsl:with-param name="chopString">
+ <xsl:call-template name="subfieldSelect">
+ <xsl:with-param name="codes">abcdfijkmnpvxyz</xsl:with-param>
+ <xsl:with-param name="subdivCodes">ijknpxyz</xsl:with-param>
+ <xsl:with-param name="subdivDelimiter">-- </xsl:with-param>
+ </xsl:call-template>
+ </xsl:with-param>
+ </xsl:call-template>
+ </a>
+ </xsl:when>
+ <xsl:otherwise/>
+ </xsl:choose>
+ <xsl:if test="not(position()=last())">
+ <xsl:text> | </xsl:text>
+ </xsl:if>
+ </xsl:template>
+
+ <xsl:template name="tag_subject">
+ <xsl:param name="tag" />
+ <xsl:param name="label" />
+ <xsl:param name="spanclass" />
+ <xsl:if test="marc:datafield[@tag=$tag]">
+ <span class="results_summary subjects {$spanclass}">
+ <span class="label">
+ <xsl:value-of select="$label"/>
+ <xsl:text>: </xsl:text>
+ </span>
+ <span class="value">
+ <xsl:for-each select="marc:datafield[@tag=$tag]">
+ <xsl:call-template name="tag_onesubject">
+ </xsl:call-template>
+ </xsl:for-each>
+ </span>
+ </span>
+ </xsl:if>
+ </xsl:template>
+
+ <xsl:template name="tag_71x">
+ <xsl:param name="tag" />
+ <xsl:param name="label" />
+ <xsl:param name="spanclass" />
+ <xsl:if test="marc:datafield[@tag=$tag]">
+ <span class="results_summary author {$spanclass}">
+ <span class="label">
+ <xsl:value-of select="$label" />
+ <xsl:text>: </xsl:text>
+ </span>
+ <span class="value">
+ <xsl:for-each select="marc:datafield[@tag=$tag]">
+ <a>
+<xsl:choose>
+ <xsl:when test="marc:subfield[@code=9]">
+ <xsl:attribute name="href">/cgi-bin/koha/opac-search.pl?q=an:<xsl:value-of select="marc:subfield[@code=9]"/></xsl:attribute>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:attribute name="href">/cgi-bin/koha/opac-search.pl?q=au:<xsl:value-of select="marc:subfield[@code='a']"/><xsl:text> </xsl:text><xsl:value-of select="marc:subfield[@code='b']"/></xsl:attribute>
+ </xsl:otherwise>
+ </xsl:choose>
+ <xsl:if test="marc:subfield[@code='a']">
+ <xsl:value-of select="marc:subfield[@code='a']"/>
+ </xsl:if>
+ <xsl:if test="marc:subfield[@code='b']">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='b']"/>
+ </xsl:if>
+ <xsl:if test="marc:subfield[@code='b'][2]">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='b'][2]"/>
+ </xsl:if>
+ <xsl:if test="marc:subfield[@code='b'][3]">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='b'][3]"/>
+ </xsl:if>
+ <xsl:if test="marc:subfield[@code='c']">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='c']"/>
+ </xsl:if>
+<xsl:choose>
+<xsl:when test="(marc:subfield[@code='d']) and (marc:subfield[@code='f']) and (marc:subfield[@code='e'])">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:text> ; </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='f']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='d']) and (marc:subfield[@code='f'])">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:text> ; </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='f']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='d']) and (marc:subfield[@code='e'])">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:text> ; </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='e']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='e']) and (marc:subfield[@code='f'])">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:text> ; </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='f']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+<xsl:when test="marc:subfield[@code='d']">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+<xsl:when test="marc:subfield[@code='e']">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='e']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+<xsl:when test="marc:subfield[@code='f']">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='f']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+</xsl:choose>
+<xsl:if test="marc:subfield[@code='4']">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='4']"/>
+<xsl:text> ) </xsl:text>
+ </xsl:if>
+ </a>
+ <xsl:if test="not (position() = last())">
+ <xsl:text> ; </xsl:text>
+ </xsl:if>
+ </xsl:for-each>
+ </span></span>
+ </xsl:if>
+ </xsl:template>
+
+
+
+ <xsl:template name="tag_7xx">
+ <xsl:param name="tag" />
+ <xsl:param name="label" />
+ <xsl:param name="spanclass" />
+ <xsl:if test="marc:datafield[@tag=$tag]">
+ <span class="results_summary author {$spanclass}">
+ <span class="label">
+ <xsl:value-of select="$label" />
+ <xsl:text>: </xsl:text>
+ </span>
+ <span class="value">
+ <xsl:for-each select="marc:datafield[@tag=$tag]">
+ <a>
+ <xsl:choose>
+ <xsl:when test="marc:subfield[@code=9]">
+ <xsl:attribute name="href">
+ <xsl:text>/cgi-bin/koha/opac-search.pl?q=an:</xsl:text>
+ <xsl:value-of select="marc:subfield[@code=9]"/>
+ </xsl:attribute>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:attribute name="href">
+ <xsl:text>/cgi-bin/koha/opac-search.pl?q=au:</xsl:text>
+ <xsl:value-of select="marc:subfield[@code='a']"/>
+ <xsl:text> </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='b']"/>
+ </xsl:attribute>
+ </xsl:otherwise>
+ </xsl:choose>
+ <xsl:for-each select="marc:subfield[@code='a' or @code='b' or @code='4' or @code='c' or @code='d' or @code='f' or @code='g' or @code='p']">
+ <xsl:choose>
+ <xsl:when test="@code='9'">
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:value-of select="."/>
+ </xsl:otherwise>
+ </xsl:choose>
+ <xsl:if test="not(position() = last())">
+ <xsl:text>, </xsl:text>
+ </xsl:if>
+ </xsl:for-each>
+ </a>
+ <xsl:if test="not(position() = last())">
+ <span style="padding: 3px;">
+ <xsl:text>;</xsl:text>
+ </span>
+ </xsl:if>
+ </xsl:for-each>
+ </span>
+ </span>
+ </xsl:if>
+ </xsl:template>
+ <xsl:template name="RCR">
+  <xsl:param name="code"/>
+  <xsl:choose>
+    <xsl:when test="$code='xxxxxxxxx'">Bibliothèque xxxxxxxxx</xsl:when>
+    <xsl:when test="$code='yyyyyyyyy'">Bibliothèque yyyyyyyyy</xsl:when>
+    <xsl:otherwise><xsl:value-of select="$code"/></xsl:otherwise>
+  </xsl:choose>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/biblibre/opac/fr-FR/UNIMARCslim2OPACDetail.xsl
+++ b/biblibre/opac/fr-FR/UNIMARCslim2OPACDetail.xsl
@@ -1,0 +1,2940 @@
+<xsl:stylesheet version="1.0"
+  xmlns:marc="http://www.loc.gov/MARC21/slim"
+  xmlns:items="http://www.koha-community.org/items"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  exclude-result-prefixes="marc items">
+
+<xsl:import href="UNIMARCslimUtils.xsl"/>
+<xsl:output method = "html" indent="yes" omit-xml-declaration = "yes" encoding="UTF-8"/>
+<xsl:template match="/">
+<xsl:apply-templates/>
+</xsl:template>
+
+<xsl:template match="marc:record">
+<xsl:variable name="Show856uAsImage" select="marc:sysprefs/marc:syspref[@name='Display856uAsImage']"/>
+<xsl:variable name="leader" select="marc:leader"/>
+<xsl:variable name="leader6" select="substring($leader,7,1)"/>
+<xsl:variable name="leader7" select="substring($leader,8,1)"/>
+<xsl:variable name="biblionumber" select="marc:controlfield[@tag=001]"/>
+<xsl:variable name="ppn" select="marc:controlfield[@tag=009]"/>
+<xsl:variable name="coverCD" select="marc:datafield[@tag=933]/marc:subfield[@code='a']"/>
+<xsl:variable name="type_doc" select="marc:datafield[@tag=099]/marc:subfield[@code='t']"/>
+
+<!--<xsl:if test="$coverCD!=' '">
+<div id='jacquette'>
+<xsl:if test="marc:datafield[@tag=933]">
+<xsl:for-each select="marc:datafield[@tag=933]">
+<img class="coverimages" height="80" width="80"><xsl:attribute name="src"><xsl:value-of select="marc:subfield[@code='a']"/></xsl:attribute></img>
+<xsl:choose>
+<xsl:when test="position()=last()"/>
+</xsl:choose>
+</xsl:for-each>
+</xsl:if> </div></xsl:if>
+-->
+
+<xsl:if test="marc:datafield[@tag=200]">
+<xsl:for-each select="marc:datafield[@tag=200]">
+<h1>
+<xsl:call-template name="addClassRtl" />
+<xsl:variable name="title" select="marc:subfield[@code='a']"/>
+<xsl:variable name="ntitle"
+select="translate($title, '&#x0098;&#x009C;&#xC29C;&#xC29B;&#xC298;&#xC288;&#xC289;','')"/>
+<!--<xsl:value-of select="$ntitle" />-->
+<xsl:value-of select="marc:subfield[@code='a'][1]" />
+<xsl:if test="marc:subfield[@code='e'][1]"><xsl:text> : </xsl:text><xsl:value-of select="marc:subfield[@code='e'][1]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='c'][1]"><xsl:text> . </xsl:text><xsl:value-of select="marc:subfield[@code='c'][1]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='d'][1]"><xsl:text> = </xsl:text><xsl:value-of select="marc:subfield[@code='d'][1]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='v'][1]"><xsl:text> . </xsl:text><xsl:value-of select="marc:subfield[@code='v'][1]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='h'][1]"><xsl:text> . </xsl:text><xsl:value-of select="marc:subfield[@code='h'][1]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='i'][1]"><xsl:text> . </xsl:text><xsl:value-of select="marc:subfield[@code='i'][1]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='e'][2]"><xsl:text> : </xsl:text><xsl:value-of select="marc:subfield[@code='e'][2]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='c'][2]"><xsl:text> . </xsl:text><xsl:value-of select="marc:subfield[@code='c'][1]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='d'][2]"><xsl:text> = </xsl:text><xsl:value-of select="marc:subfield[@code='d'][2]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='h'][2]"><xsl:text> . </xsl:text><xsl:value-of select="marc:subfield[@code='h'][2]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='i'][2]"><xsl:text> . </xsl:text><xsl:value-of select="marc:subfield[@code='i'][2]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='e'][3]"><xsl:text> : </xsl:text><xsl:value-of select="marc:subfield[@code='e'][3]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='c'][3]"><xsl:text> . </xsl:text><xsl:value-of select="marc:subfield[@code='c'][3]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='d'][3]"><xsl:text> = </xsl:text><xsl:value-of select="marc:subfield[@code='d'][3]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='h'][3]"><xsl:text> . </xsl:text><xsl:value-of select="marc:subfield[@code='h'][3]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='i'][3]"><xsl:text> . </xsl:text><xsl:value-of select="marc:subfield[@code='i'][3]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='a'][2]"><xsl:text>. </xsl:text><xsl:value-of select="marc:subfield[@code='a'][2]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='a'][3]"><xsl:text>. </xsl:text><xsl:value-of select="marc:subfield[@code='a'][3]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='b']"><xsl:text> [</xsl:text><xsl:value-of select="marc:subfield[@code='b']"/><xsl:text>] </xsl:text>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='f']">
+<xsl:text> / </xsl:text>
+<xsl:if test="marc:subfield[@code='f'][1]"><xsl:text></xsl:text><xsl:value-of select="marc:subfield[@code='f'][1]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='f'][2]"><xsl:text> ; </xsl:text><xsl:value-of select="marc:subfield[@code='f'][2]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='f'][3]"><xsl:text> ; </xsl:text><xsl:value-of select="marc:subfield[@code='f'][3]" /></xsl:if>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='g'][1]"><xsl:text> ; </xsl:text><xsl:value-of select="marc:subfield[@code='g'][1]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='g'][2]"><xsl:text> ; </xsl:text><xsl:value-of select="marc:subfield[@code='g'][2]" /></xsl:if>
+<xsl:if test="marc:subfield[@code='g'][3]"><xsl:text> ; </xsl:text><xsl:value-of select="marc:subfield[@code='g'][3]" /></xsl:if>
+</h1>
+</xsl:for-each>
+</xsl:if>
+
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">412</xsl:with-param>
+<xsl:with-param name="label">Est un extrait ou tiré à part de</xsl:with-param>
+</xsl:call-template>
+
+<!--413 Extrait ou tiré à part-->
+<xsl:for-each select="marc:datafield[@tag=413]">
+<span class="results_summary">
+<span class="label">A pour extrait ou tiré à part : </span>
+<xsl:choose>
+<xsl:when test="(marc:subfield[@code='t']) and (marc:subfield[@code='o']) and  (marc:subfield[@code='f']) and (marc:subfield[@code='c']) and (marc:subfield[@code='n']) and (marc:subfield[@code='d'])">
+ <xsl:value-of select="marc:subfield[@code='t']"/>
+<xsl:text> : </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='o']"/>
+<xsl:text> / </xsl:text>
+<xsl:value-of select="marc:subfield[@code='f']"/>
+ <xsl:text>. - </xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+ <xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='n']"/>
+ <xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='t']) and (marc:subfield[@code='o']) and (marc:subfield[@code='c']) and (marc:subfield[@code='n']) and (marc:subfield[@code='d'])">
+ <xsl:value-of select="marc:subfield[@code='t']"/>
+<xsl:text> : </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='o']"/>
+ <xsl:text>. - </xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+ <xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='n']"/>
+ <xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='t']) and (marc:subfield[@code='f']) and (marc:subfield[@code='c']) and (marc:subfield[@code='n']) and (marc:subfield[@code='d'])">
+ <xsl:value-of select="marc:subfield[@code='t']"/>
+<xsl:text> / </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='f']"/>
+ <xsl:text>. - </xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+ <xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='n']"/>
+ <xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='t']) and (marc:subfield[@code='c']) and (marc:subfield[@code='n']) and (marc:subfield[@code='d'])">
+ <xsl:value-of select="marc:subfield[@code='t']"/>
+ <xsl:text>. - </xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+ <xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='n']"/>
+ <xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+</xsl:when>
+<xsl:when test="marc:subfield[@code='t']">
+ <xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:when>
+</xsl:choose>
+ </span>
+ </xsl:for-each>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">421</xsl:with-param>
+<xsl:with-param name="label">A pour supplément</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">422</xsl:with-param>
+<xsl:with-param name="label">Est un supplément de</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">423</xsl:with-param>
+<xsl:with-param name="label">Est publié avec</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">424</xsl:with-param>
+<xsl:with-param name="label">Est mis à jour par</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">430</xsl:with-param>
+<xsl:with-param name="label">Suite de</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">431</xsl:with-param>
+<xsl:with-param name="label">Succède après scission à</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">432</xsl:with-param>
+<xsl:with-param name="label">Remplace</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">433</xsl:with-param>
+<xsl:with-param name="label">Remplace partiellement</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">434</xsl:with-param>
+<xsl:with-param name="label">Absorbe</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">435</xsl:with-param>
+<xsl:with-param name="label">Absorbe partiellement</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">436</xsl:with-param>
+<xsl:with-param name="label">Fusion de</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">437</xsl:with-param>
+<xsl:with-param name="label">Suite partielle de</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">440</xsl:with-param>
+<xsl:with-param name="label">Devient</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">441</xsl:with-param>
+<xsl:with-param name="label">Devient partiellement</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">442</xsl:with-param>
+<xsl:with-param name="label">Remplacé par</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">443</xsl:with-param>
+<xsl:with-param name="label">Remplacé partiellement par</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">444</xsl:with-param>
+<xsl:with-param name="label">Absorbé par</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">447</xsl:with-param>
+<xsl:with-param name="label">Fusionné avec...pour former</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">451</xsl:with-param>
+<xsl:with-param name="label">A pour autre édition, sur le même support</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">452</xsl:with-param>
+<xsl:with-param name="label">A pour autre édition, sur un support différent</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">453</xsl:with-param>
+<xsl:with-param name="label">Traduit sous le titre</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">454</xsl:with-param>
+<xsl:with-param name="label">Est une traduction de</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">455</xsl:with-param>
+<xsl:with-param name="label">Est une reproduction de</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">456</xsl:with-param>
+<xsl:with-param name="label">Est reproduit comme</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">464</xsl:with-param>
+<xsl:with-param name="label">Composante</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">470</xsl:with-param>
+<xsl:with-param name="label">Document analysé</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">481</xsl:with-param>
+<xsl:with-param name="label">Est aussi relié dans ce volume</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">482</xsl:with-param>
+<xsl:with-param name="label">Relié à la suite de</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">488</xsl:with-param>
+<xsl:with-param name="label">Autres oeuvres en liaison</xsl:with-param>
+</xsl:call-template>
+
+<xsl:if test="contains($type_doc,'Périodique')">
+<xsl:choose>
+<xsl:when test="$ppn">
+<xsl:call-template name="tag_462_ppn" />
+</xsl:when>
+<xsl:otherwise>
+<xsl:call-template name="tag_462" />
+</xsl:otherwise>
+</xsl:choose>
+</xsl:if>
+
+<!--Titre de serie autorite 461-->
+<!--<xsl:call-template name="tag_461" />-->
+
+<!---Titre de serie non autorite 461-->
+<xsl:call-template name="tag_461bis" />
+
+<!--Titre dépouillé 463-->
+<xsl:call-template name="tag_463" />
+
+
+<xsl:if test="marc:datafield[@tag=531]"> 
+<span class="results_summary">
+<span class="label">Titre abrégé : </span>
+<xsl:for-each select="marc:datafield[@tag=531]">
+<xsl:for-each select="marc:subfield">
+<xsl:value-of select="text()"/>
+<xsl:choose>
+<xsl:when test="position()=last()">
+<xsl:text>.</xsl:text>
+</xsl:when>
+<xsl:otherwise><xsl:text>, </xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:for-each>
+</xsl:for-each>
+</span>
+</xsl:if>
+
+<xsl:if test="marc:datafield[@tag=540]">
+<span class="results_summary">
+<span class="label">Titre ajouté par le catalogueur : </span>
+<xsl:for-each select="marc:datafield[@tag=540]">
+<xsl:for-each select="marc:subfield">
+<xsl:value-of select="text()"/>
+<xsl:choose>
+<xsl:when test="position()=last()">
+<xsl:text>.</xsl:text>
+</xsl:when>
+<xsl:otherwise><xsl:text>, </xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:for-each>
+</xsl:for-each>
+</span>
+</xsl:if>
+
+<xsl:if test="marc:datafield[@tag=541]">
+<span class="results_summary">
+<span class="label">Titre traduit par le catalogueur : </span>
+<xsl:for-each select="marc:datafield[@tag=541]">
+<xsl:for-each select="marc:subfield">
+<xsl:value-of select="text()"/>
+<xsl:choose>
+<xsl:when test="position()=last()">
+<xsl:text>.</xsl:text>
+</xsl:when>
+<xsl:otherwise><xsl:text>, </xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:for-each>
+</xsl:for-each>
+</span>
+</xsl:if>
+
+
+<xsl:if test="marc:datafield[@tag=099]/marc:subfield[@code='t']">
+  <span class="results_summary">
+    <span class="label">Catégorie de document : </span>
+    <xsl:for-each select="marc:datafield[@tag=099]/marc:subfield[@code='t']">
+      <xsl:value-of select="."/>
+      <xsl:if test="not(position()=last())"><xsl:text> ; </xsl:text></xsl:if>
+    </xsl:for-each>
+  </span>
+</xsl:if>
+
+ <xsl:call-template name="tag_7xx">
+ <xsl:with-param name="tag">700</xsl:with-param>
+ <xsl:with-param name="label">Auteur(s)</xsl:with-param>
+ </xsl:call-template>
+
+ <xsl:call-template name="tag_71x">
+ <xsl:with-param name="tag">710</xsl:with-param>
+ <xsl:with-param name="label">Auteur(s)</xsl:with-param>
+ </xsl:call-template>
+
+ <xsl:call-template name="tag_7xx">
+ <xsl:with-param name="tag">701</xsl:with-param>
+ <xsl:with-param name="label">Auteur(s)</xsl:with-param>
+ </xsl:call-template>
+
+ <xsl:call-template name="tag_7xx">
+ <xsl:with-param name="tag">702</xsl:with-param>
+ <xsl:with-param name="label">Auteur(s)</xsl:with-param>
+ </xsl:call-template>
+
+ <xsl:call-template name="tag_71x">
+ <xsl:with-param name="tag">711</xsl:with-param>
+ <xsl:with-param name="label">Auteur(s)</xsl:with-param>
+ </xsl:call-template>
+
+ <xsl:call-template name="tag_71x">
+ <xsl:with-param name="tag">712</xsl:with-param>
+ <xsl:with-param name="label">Auteur(s)</xsl:with-param>
+ </xsl:call-template>
+
+<xsl:if test="marc:datafield[@tag=101]"> 
+<span class="results_summary">
+<span class="label">Langue(s) : </span>
+<xsl:for-each select="marc:datafield[@tag=101]">
+<xsl:for-each select="marc:subfield">
+<xsl:value-of select="text()"/>
+ <!--<xsl:choose>
+ <xsl:when test="@code='b'">du texte intermédiaire, </xsl:when>
+ <xsl:when test="@code='c'">de l'oeuvre originale, </xsl:when>
+ <xsl:when test="@code='d'">du résumé, </xsl:when>
+ <xsl:when test="@code='e'">de la table des matières, </xsl:when>
+ <xsl:when test="@code='f'">de la page de titre, </xsl:when>
+ <xsl:when test="@code='g'">du titre propre, </xsl:when>
+ <xsl:when test="@code='h'">du livret ou des paroles, </xsl:when>
+ <xsl:when test="@code='i'">du matériel d'accompagnement, </xsl:when>
+ <xsl:when test="@code='j'">des sous-titres </xsl:when>n> </xsl:choose>
+ <xsl:value-of select="text()"/>-->
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text>.</xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> ; </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+ </xsl:for-each>
+ </span>
+ </xsl:if>
+
+<xsl:if test="marc:datafield[@tag=102]">
+<span class="results_summary">
+<span class="label">Pays : </span>
+<xsl:for-each select="marc:datafield[@tag=102]">
+<xsl:for-each select="marc:subfield">
+<xsl:value-of select="text()"/>
+<xsl:choose>
+<xsl:when test="position()=last()">
+<xsl:text>.</xsl:text>
+</xsl:when>
+<xsl:otherwise><xsl:text>, </xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:for-each>
+</xsl:for-each>
+</span>
+</xsl:if>
+
+
+<xsl:if test="marc:datafield[@tag=205]">
+<span class="results_summary">
+<span class="label">Edition : </span>
+<xsl:for-each select="marc:datafield[@tag=205]">
+<xsl:for-each select="marc:subfield">
+<xsl:value-of select="text()"/>
+<xsl:choose>
+<xsl:when test="position()=last()">
+<xsl:text>.</xsl:text>
+</xsl:when>
+<xsl:otherwise><xsl:text>, </xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:for-each>
+</xsl:for-each>
+</span>
+</xsl:if>
+
+<xsl:if test="(marc:datafield[@tag=214] or marc:datafield[@tag=210])">
+<xsl:choose>
+<xsl:when test="(marc:datafield[@tag=214]/marc:subfield[@code='r'])">
+<xsl:call-template name="tag_214_r" />
+</xsl:when>
+<xsl:when test="(marc:datafield[@tag=214]/marc:subfield[@code='s'])">
+<xsl:call-template name="tag_214_s" />
+</xsl:when>
+<xsl:when test="(marc:datafield[@tag=210]/marc:subfield[@code='r'])">
+<xsl:call-template name="tag_210_r" />
+</xsl:when>
+<xsl:when test="(marc:datafield[@tag=210]/marc:subfield[@code='s'])">
+<xsl:call-template name="tag_210_s" />
+</xsl:when>
+<xsl:when test="(marc:datafield[@tag=214] and  marc:datafield[@tag=210])">
+<xsl:call-template name="tag_214" />
+</xsl:when>
+<xsl:when test="(marc:datafield[@tag=214])">
+<xsl:call-template name="tag_214" />
+</xsl:when>
+<xsl:when test="(marc:datafield[@tag=210])">
+<xsl:call-template name="tag_210" />
+</xsl:when>
+</xsl:choose>
+</xsl:if>
+
+
+<xsl:call-template name="tag_215" />
+
+<xsl:if test="marc:controlfield[@tag=009]">
+<span class="results_summary">
+<span class="label">SUDOC : </span>
+<a><xsl:attribute name="href">http://www.sudoc.fr/<xsl:value-of select="$ppn"/></xsl:attribute><xsl:value-of select="$ppn"/></a>
+</span>
+</xsl:if>
+
+<!--ISBN-->
+<xsl:if test="(marc:datafield[@tag=010]/marc:subfield[@code='a']) or (marc:datafield[@tag=010]/marc:subfield[@code='b']) or (marc:datafield[@tag=010]/marc:subfield[@code='z'])">
+
+
+ <span class="results_summary">
+<span class="label">ISBN : </span>
+ <xsl:for-each select="marc:datafield[@tag=010]">
+
+ <xsl:choose>
+ <xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='b']) and (marc:subfield[@code='z'])">
+ <xsl:value-of select="marc:subfield[@code='a']"/>
+ <xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='z']"/><xsl:text>(erroné)</xsl:text>
+<xsl:text>  </xsl:text>
+<xsl:text>(</xsl:text><xsl:value-of select="marc:subfield[@code='b']"/><xsl:text>)</xsl:text>
+ </xsl:when>
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='b'])">
+ <xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text>  </xsl:text>
+<xsl:text>(</xsl:text><xsl:value-of select="marc:subfield[@code='b']"/><xsl:text>)</xsl:text>
+ </xsl:when>
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='z'])">
+ <xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='z']"/><xsl:text>(erroné)</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='b']) and (marc:subfield[@code='z'])">
+ <xsl:value-of select="marc:subfield[@code='z']"/>
+<xsl:text>(erroné) </xsl:text><xsl:text>(</xsl:text>
+<xsl:value-of select="marc:subfield[@code='b']"/><xsl:text>)</xsl:text>
+</xsl:when>
+ <xsl:when test="(marc:subfield[@code='a'])">
+ <xsl:value-of select="marc:subfield[@code='a']"/>
+ </xsl:when>
+<xsl:when test="(marc:subfield[@code='b'])">
+ <xsl:value-of select="marc:subfield[@code='b']"/>
+ </xsl:when>
+<xsl:when test="(marc:subfield[@code='d'])">
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+ </xsl:when>
+</xsl:choose>
+<xsl:choose>
+<xsl:when test="position()=last()">
+<xsl:text> </xsl:text>
+</xsl:when>
+<xsl:otherwise><xsl:text> .- </xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:for-each>
+</span>
+</xsl:if>
+
+
+
+
+<xsl:if test="marc:datafield[@tag=010]/marc:subfield[@code='d']">
+<span class="results_summary">
+<span class="label">Prix : </span>
+<xsl:for-each select="marc:datafield[@tag=010]">
+<xsl:variable name="isbn" select="marc:subfield[@code='d']"/>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:choose>
+<xsl:when test="position()=last()">
+<xsl:text>.</xsl:text>
+</xsl:when>
+<xsl:otherwise>
+<xsl:text> ; </xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:for-each>
+</span>
+</xsl:if>
+
+<xsl:if test="marc:datafield[@tag=011]">
+<span class="results_summary">
+<span class="label">ISSN : </span>
+<xsl:for-each select="marc:datafield[@tag=011]">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:choose>
+<xsl:when test="position()=last()">
+<xsl:text>.</xsl:text>
+</xsl:when>
+<xsl:otherwise>
+<xsl:text>; </xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:for-each>
+</span>
+</xsl:if>
+
+ <xsl:call-template name="tag_title">
+ <xsl:with-param name="tag">225</xsl:with-param>
+ <xsl:with-param name="label">Collection</xsl:with-param>
+ </xsl:call-template>
+
+<!--410 Collection-->
+<xsl:for-each select="marc:datafield[@tag=410]">
+<span class="results_summary">
+<span class="label">Appartient à la collection : </span>
+<xsl:choose>
+<xsl:when test="(marc:subfield[@code='9']) and (marc:subfield[@code='x']) and (marc:subfield[@code='v'])">
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?q=an:<xsl:value-of select="marc:subfield[@code='9']"/></xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:element>
+<xsl:text>, ISSN </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?idx=ns&amp;q=<xsl:value-of select="marc:subfield[@code='x']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x']"/></xsl:element>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='v']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='9'])  and (marc:subfield[@code='v'])">
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?q=an:<xsl:value-of select="marc:subfield[@code='9']"/></xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:element>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='v']"/>
+      </xsl:when>
+<xsl:when test="(marc:subfield[@code='9']) and (marc:subfield[@code='x'])">
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?q=an:<xsl:value-of select="marc:subfield[@code='9']"/></xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:element>
+<xsl:text>, ISSN </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?idx=ns&amp;q=<xsl:value-of select="marc:subfield[@code='x']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x']"/></xsl:element>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='t']) and (marc:subfield[@code='x']) and (marc:subfield[@code='v'])">
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?idx=Title-series&amp;q=<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='t']"/></xsl:element>
+<xsl:text>, ISSN </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?idx=ns&amp;q=<xsl:value-of select="marc:subfield[@code='x']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x']"/></xsl:element>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='v']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='t'])  and (marc:subfield[@code='v'])">
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?idx=Title-series&amp;q=<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='t']"/></xsl:element>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='v']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='t'])">
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?idx=Title-series&amp;q=<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='t']"/></xsl:element>
+</xsl:when>
+ </xsl:choose>
+</span>
+</xsl:for-each>
+
+
+
+<!--500 DE UNIFORME-->
+<xsl:for-each select="marc:datafield[@tag=500]">
+<span class="results_summary">
+<span class="label">Titre uniforme : </span>
+ <xsl:if test="marc:subfield[@code='a']">
+<xsl:text>[</xsl:text>
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:choose>
+<xsl:when test="(marc:subfield[@code='i']) and (marc:subfield[@code='m']) and  (marc:subfield[@code='k'])">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='i']"/>
+<xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='m']"/>
+<xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='k']"/>
+ <xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='i']) and (marc:subfield[@code='l'])">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='i']"/>
+<xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='l']"/>
+ <xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='m']) and (marc:subfield[@code='k'])">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='m']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='k']"/>
+ <xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='i']) and (marc:subfield[@code='k'])">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='i']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='k']"/>
+ <xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='i'][3])">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='i'][1]"/>
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='i'][2]"/>
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='i'][3]"/>
+ <xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='i'][2])">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='i'][1]"/>
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='i'][2]"/>
+ <xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='l'])">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='l']"/>
+ <xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:otherwise>
+<xsl:text>]</xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:if>
+ </span>
+ </xsl:for-each>
+
+
+<!--503 TITRE FORME-->
+<xsl:for-each select="marc:datafield[@tag=503]">
+ <span class="results_summary">
+<span class="label">Titre de forme : </span>
+ <xsl:if test="marc:subfield[@code='a']">
+<xsl:text>[</xsl:text>
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:choose>
+<xsl:when test="(marc:subfield[@code='e']) and (marc:subfield[@code='i']) and  (marc:subfield[@code='m']) and  (marc:subfield[@code='n']) and (marc:subfield[@code='o']) and (marc:subfield[@code='j'])">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='i']"/>
+<xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='m']"/>
+<xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='n']"/>
+<xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='o']"/>
+<xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='j']"/>
+ <xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='e']) and (marc:subfield[@code='m']) and (marc:subfield[@code='n']) and (marc:subfield[@code='o']) and (marc:subfield[@code='j'])">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='m']"/>
+<xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='n']"/>
+<xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='o']"/>
+<xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='j']"/>
+ <xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='m']) and (marc:subfield[@code='n']) and (marc:subfield[@code='o']) and (marc:subfield[@code='j'])">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='m']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='n']"/>
+<xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='o']"/>
+<xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='j']"/>
+ <xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='e']) and (marc:subfield[@code='m']) and (marc:subfield[@code='n']) and (marc:subfield[@code='j'])">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='e']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='m']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='n']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='j']"/>
+<xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='m']) and (marc:subfield[@code='n']) and (marc:subfield[@code='j'])">
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='m']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='n']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='j']"/>
+<xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='e']) and (marc:subfield[@code='h']) and (marc:subfield[@code='j'])">
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='h']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='j']"/>
+<xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='e']) and (marc:subfield[@code='f']) and (marc:subfield[@code='h'])">
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='f']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='h']"/>
+<xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='e']) and (marc:subfield[@code='f'])">
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='f']"/>
+<xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='i']) and (marc:subfield[@code='n'])">
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='i']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='n']"/>
+<xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='m']) and (marc:subfield[@code='n'])">
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='m']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='n']"/>
+<xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='m']) and (marc:subfield[@code='j'])">
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='m']"/>
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='j']"/>
+<xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='m'])">
+ <xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='m']"/>
+<xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:otherwise>
+<xsl:text>]</xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:if>
+</span>
+</xsl:for-each>
+
+
+<!--517 AUTRE TITRE-->
+<xsl:for-each select="marc:datafield[@tag=517]">
+<span class="results_summary">
+<span class="label">Autre(s) titre(s) : </span>
+ <xsl:if test="marc:subfield[@code='a']">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:choose>
+<xsl:when test="(marc:subfield[@code='e']) and (marc:subfield[@code='h']) and  (marc:subfield[@code='i'])">
+ <xsl:text>: </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='h']"/>
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='i']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='e'])">
+ <xsl:text>: </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='e']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='j'])">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='j']"/>
+</xsl:when>
+</xsl:choose>
+</xsl:if>
+</span>
+</xsl:for-each>
+
+
+<xsl:if test="marc:datafield[@tag=686]">
+<span class="results_summary">
+<span class="label">Autre classification :  </span>
+<xsl:for-each select="marc:datafield[@tag=686]">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:if test="marc:subfield[@code='2']">
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='2']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='z']">
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='z']"/>
+</xsl:if>
+<xsl:if test="not (position()=last())">
+<xsl:text> ; </xsl:text>
+</xsl:if>
+</xsl:for-each>
+</span>
+</xsl:if>
+
+<xsl:if test="marc:datafield[@tag=675]">
+<span class="results_summary">
+<span class="label">Classification - CDU : </span>
+<xsl:for-each select="marc:datafield[@tag=675]">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:if test="marc:subfield[@code='b']">
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='b']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='c']">
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:if>
+<xsl:if test="not (position()=last())"><xsl:text> ; </xsl:text></xsl:if>
+</xsl:for-each>
+</span>
+</xsl:if>
+
+
+<xsl:if test="marc:datafield[@tag=676]">
+<span class="results_summary">
+<span class="label">Classification - Dewey : </span>
+<xsl:for-each select="marc:datafield[@tag=676]">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:if test="marc:subfield[@code='b']">
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='b']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='c']">
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:if>
+<xsl:if test="not (position()=last())"><xsl:text> ; </xsl:text></xsl:if>
+</xsl:for-each>
+</span>
+</xsl:if>
+
+<!--onglet Description-->
+<div id="tab-content-descr" class="tab-content">
+<p>
+ <xsl:if test="marc:datafield[@tag=300]">
+ <span class="results_summary">
+ <span class="label">Note générale : </span>
+ <xsl:for-each select="marc:datafield[@tag=300]">
+  <xsl:for-each select="marc:subfield[@code='a']">
+<xsl:value-of select="."/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> | </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+ </xsl:for-each>
+ </span>
+ </xsl:if>
+</p>
+<p>
+<xsl:if test="marc:datafield[@tag=303]">
+ <span class="results_summary">
+ <span class="label">Note sur la description bibliographique : </span>
+<xsl:for-each select="marc:datafield[@tag=303]">
+ <xsl:for-each select="marc:subfield[@code='a']">
+<xsl:value-of select="."/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> | </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+</xsl:for-each>
+</span>
+</xsl:if>
+</p>
+<p>
+<xsl:if test="marc:datafield[@tag=304]">
+ <span class="results_summary">
+ <span class="label">Note sur le titre et les responsabilités : </span>
+<xsl:for-each select="marc:datafield[@tag=304]">
+ <xsl:for-each select="marc:subfield[@code='a']">
+<xsl:value-of select="."/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> | </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+</xsl:for-each>
+</span>
+</xsl:if>
+</p>
+<p>
+<xsl:if test="marc:datafield[@tag=305]">
+ <span class="results_summary">
+ <span class="label">Note sur l'édition et l'histoire : </span>
+<xsl:for-each select="marc:datafield[@tag=305]">
+ <xsl:for-each select="marc:subfield[@code='a']">
+<xsl:value-of select="."/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> | </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+</xsl:for-each>
+</span>
+</xsl:if>
+</p>
+<p>
+<xsl:if test="marc:datafield[@tag=306]">
+ <span class="results_summary">
+ <span class="label">Note sur la publication, production : </span>
+<xsl:for-each select="marc:datafield[@tag=306]">
+ <xsl:for-each select="marc:subfield[@code='a']">
+<xsl:value-of select="."/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> | </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+</xsl:for-each>
+</span>
+</xsl:if>
+</p>
+<p>
+<xsl:if test="marc:datafield[@tag=307]">
+ <span class="results_summary">
+ <span class="label">Note sur la description matérielle : </span>
+<xsl:for-each select="marc:datafield[@tag=307]">
+ <xsl:for-each select="marc:subfield[@code='a']">
+<xsl:value-of select="."/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> | </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+</xsl:for-each>
+</span>
+</xsl:if>
+</p>
+<p>
+<xsl:if test="marc:datafield[@tag=308]">
+ <span class="results_summary">
+ <span class="label">Note sur la collection : </span>
+<xsl:for-each select="marc:datafield[@tag=308]">
+ <xsl:for-each select="marc:subfield[@code='a']">
+<xsl:value-of select="."/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> | </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+</xsl:for-each>
+</span>
+</xsl:if>
+</p>
+<p>
+<xsl:if test="marc:datafield[@tag=310]">
+ <span class="results_summary">
+ <span class="label">Note sur la disponiblité : </span>
+<xsl:for-each select="marc:datafield[@tag=310]">
+ <xsl:for-each select="marc:subfield[@code='a']">
+<xsl:value-of select="."/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> | </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+</xsl:for-each>
+</span>
+</xsl:if>
+</p>
+<p>
+<xsl:if test="marc:datafield[@tag=311]">
+ <span class="results_summary">
+ <span class="label">Note sur les zones de liens : </span>
+<xsl:for-each select="marc:datafield[@tag=311]">
+ <xsl:for-each select="marc:subfield[@code='a']">
+<xsl:value-of select="."/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> | </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+</xsl:for-each>
+</span>
+</xsl:if>
+</p>
+<p>
+<xsl:if test="marc:datafield[@tag=312]">
+ <span class="results_summary">
+ <span class="label">Note sur les titres associés : </span>
+<xsl:for-each select="marc:datafield[@tag=312]">
+ <xsl:for-each select="marc:subfield[@code='a']">
+<xsl:value-of select="."/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> | </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+</xsl:for-each>
+</span>
+</xsl:if>
+</p>
+<p>
+<xsl:if test="marc:datafield[@tag=314]">
+ <span class="results_summary">
+ <span class="label">Note sur la responsabilité : </span>
+<xsl:for-each select="marc:datafield[@tag=314]">
+ <xsl:for-each select="marc:subfield[@code='a']">
+<xsl:value-of select="."/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> | </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+</xsl:for-each>
+</span>
+</xsl:if>
+</p>
+<p>
+<xsl:if test="marc:datafield[@tag=315]">
+ <span class="results_summary">
+ <span class="label">Note relative à la ressource : </span>
+<xsl:for-each select="marc:datafield[@tag=315]">
+ <xsl:for-each select="marc:subfield[@code='a']">
+<xsl:value-of select="."/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> | </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+</xsl:for-each>
+</span>
+</xsl:if>
+</p>
+<!--316 Note sur l'exemplaire-->
+<p>
+<xsl:for-each select="marc:datafield[@tag=316]">
+ <span class="results_summary">
+ <span class="label">Note sur l'exemplaire : </span>
+<xsl:if test="(marc:subfield[@code='a'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text>. </xsl:text>
+</xsl:if>
+<xsl:if test="(marc:subfield[@code='5'])">
+<xsl:value-of select="marc:subfield[@code='5']"/>
+<xsl:text>. </xsl:text>
+</xsl:if>
+</span>
+</xsl:for-each>
+</p>
+<!--317 Note sur la provenance-->
+<p>
+<xsl:for-each select="marc:datafield[@tag=317]">
+ <span class="results_summary">
+ <span class="label">Note sur la provenance : </span>
+<xsl:if test="(marc:subfield[@code='a'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text>. </xsl:text>
+</xsl:if>
+<xsl:if test="(marc:subfield[@code='5'])">
+<xsl:value-of select="marc:subfield[@code='5']"/>
+<xsl:text>. </xsl:text>
+</xsl:if>
+</span>
+</xsl:for-each>
+</p>
+<p>
+<xsl:for-each select="marc:datafield[@tag=320]">
+ <span class="results_summary">
+ <span class="label">Note sur les bibliographies et les index : </span>
+<xsl:if test="(marc:subfield[@code='a'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text>. </xsl:text>
+</xsl:if>
+<xsl:if test="(marc:subfield[@code='u'])">
+<xsl:value-of select="marc:subfield[@code='u']"/>
+<xsl:text>. </xsl:text>
+</xsl:if>
+</span>
+</xsl:for-each>
+</p>
+<p>
+<xsl:for-each select="marc:datafield[@tag=321]">
+ <span class="results_summary">
+ <span class="label">Note sur les  index, extrait, citations publiés séparément : </span>
+<xsl:if test="(marc:subfield[@code='a'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text>. </xsl:text>
+</xsl:if>
+<xsl:if test="(marc:subfield[@code='u'])">
+<xsl:value-of select="marc:subfield[@code='u']"/>
+<xsl:text>. </xsl:text>
+</xsl:if>
+</span>
+</xsl:for-each>
+</p>
+<p>
+<xsl:for-each select="marc:datafield[@tag=322]">
+ <span class="results_summary">
+ <span class="label">Note sur le générique : </span>
+<xsl:if test="(marc:subfield[@code='a'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text>. </xsl:text>
+</xsl:if>
+<xsl:if test="(marc:subfield[@code='u'])">
+<xsl:value-of select="marc:subfield[@code='u']"/>
+<xsl:text>. </xsl:text>
+</xsl:if>
+</span>
+</xsl:for-each>
+</p>
+<p>
+<xsl:for-each select="marc:datafield[@tag=323]">
+ <span class="results_summary">
+ <span class="label">Note sur les interprètes : </span>
+<xsl:if test="(marc:subfield[@code='a'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text>. </xsl:text>
+</xsl:if>
+<xsl:if test="(marc:subfield[@code='u'])">
+<xsl:value-of select="marc:subfield[@code='u']"/>
+<xsl:text>. </xsl:text>
+</xsl:if>
+</span>
+</xsl:for-each>
+</p>
+<p>
+<xsl:for-each select="marc:datafield[@tag=324]">
+ <span class="results_summary">
+ <span class="label">Note sur l’original reproduit : </span>
+<xsl:if test="(marc:subfield[@code='a'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text>. </xsl:text>
+</xsl:if>
+<xsl:if test="(marc:subfield[@code='u'])">
+<xsl:value-of select="marc:subfield[@code='u']"/>
+<xsl:text>. </xsl:text>
+</xsl:if>
+</span>
+</xsl:for-each>
+</p>
+<p>
+<xsl:if test="marc:datafield[@tag=325]">
+ <span class="results_summary">
+ <span class="label">Note sur la reproduction : </span>
+<xsl:for-each select="marc:datafield[@tag=325]">
+ <xsl:for-each select="marc:subfield[@code='a']">
+<xsl:value-of select="."/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> | </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+</xsl:for-each>
+</span>
+</xsl:if>
+</p>
+<p>
+ <xsl:if test="marc:datafield[@tag=327]">
+  <span class="results_summary">
+ <span class="label">Note de contenu : </span>
+ <xsl:for-each select="marc:datafield[@tag=327]">
+ <xsl:for-each select="marc:subfield[@code='a']">
+<xsl:value-of select="."/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> | </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+  </xsl:for-each>
+</span>
+ </xsl:if>
+</p>
+<p>
+<xsl:if test="marc:datafield[@tag=326]">
+  <span class="results_summary">
+ <span class="label">Périodicité : </span>
+ <xsl:for-each select="marc:datafield[@tag=326]">
+ <xsl:value-of select="marc:subfield[@code='a']"/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text>; </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+ </span>
+ </xsl:if>
+ </p>
+ <p>
+ <xsl:if test="marc:datafield[@tag=328]">
+  <span class="results_summary">
+ <span class="label">Note de thèse : </span>
+ <xsl:for-each select="marc:datafield[@tag=328]">
+<xsl:for-each select="marc:subfield">
+ <xsl:value-of select="text()"/>
+ <xsl:choose><xsl:when test="position()=last()"><xsl:text> . </xsl:text></xsl:when><xsl:otherwise><xsl:text> - </xsl:text></xsl:otherwise></xsl:choose>
+ </xsl:for-each>
+ </xsl:for-each>
+ </span>
+ </xsl:if>
+</p>
+<p>
+<xsl:if test="marc:datafield[@tag=336]">
+  <span class="results_summary">
+ <span class="label">Type de ressources électronique : </span>
+ <xsl:for-each select="marc:datafield[@tag=336]">
+<xsl:for-each select="marc:subfield">
+ <xsl:value-of select="text()"/>
+ <xsl:choose><xsl:when test="position()=last()"><xsl:text> . </xsl:text></xsl:when><xsl:otherwise><xsl:text> - </xsl:text></xsl:otherwise></xsl:choose>
+ </xsl:for-each>
+ </xsl:for-each>
+ </span>
+ </xsl:if>
+</p>
+<p>
+<xsl:if test="marc:datafield[@tag=337]">
+  <span class="results_summary">
+ <span class="label">Note de thèses et écrits académiques : </span>
+ <xsl:for-each select="marc:datafield[@tag=337]">
+<xsl:for-each select="marc:subfield">
+ <xsl:value-of select="text()"/>
+ <xsl:choose><xsl:when test="position()=last()"><xsl:text> . </xsl:text></xsl:when><xsl:otherwise><xsl:text> - </xsl:text></xsl:otherwise></xsl:choose>
+ </xsl:for-each>
+ </xsl:for-each>
+ </span>
+ </xsl:if>
+</p>
+
+
+<xsl:if test="marc:datafield[@tag=330]">
+<span class="results_summary">
+<span class="label">Résumé : </span>
+<xsl:for-each select="marc:datafield[@tag=330]">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <br></br><xsl:text> </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+</xsl:for-each>
+</span>
+</xsl:if>
+
+<!--<xsl:for-each select="marc:datafield[@tag=359]">
+ <xsl:for-each select="node()">
+<dd><xsl:value-of select="."/></dd>
+</xsl:for-each> </xsl:for-each>-->
+
+<xsl:if test="marc:datafield[@tag=359]">
+<xsl:for-each select="marc:datafield[@tag=359]">
+<xsl:for-each select="marc:subfield">
+<xsl:choose>
+ <xsl:when test="@code='b'"><dt class="col-sm-4"><xsl:value-of select="text()"/></dt></xsl:when>
+ <xsl:when test="@code='c'"><dd class="col-sm-4"><xsl:value-of select="text()"/></dd></xsl:when>
+ <xsl:when test="@code='d'"><ul><dd class="col-sm-4"><xsl:value-of select="text()"/></dd></ul></xsl:when>
+ <xsl:when test="@code='e'"><ul><ul><dd class="col-sm-4"><xsl:value-of select="text()"/></dd></ul></ul></xsl:when>
+ <xsl:when test="@code='f'"><ul><ul><dd class="col-sm-4"> <xsl:value-of select="text()"/></dd></ul></ul></xsl:when>
+ <xsl:when test="@code='g'"><ul><ul><dd class="col-sm-4"><xsl:value-of select="text()"/></dd></ul></ul></xsl:when>
+ <xsl:when test="@code='h'"><ul><ul><dd class="col-sm-4"><xsl:value-of select="text()"/></dd></ul></ul></xsl:when>
+ <xsl:when test="@code='i'"><ul><ul><dd class="col-sm-4"><xsl:value-of select="text()"/></dd></ul></ul></xsl:when>
+ <xsl:when test="@code='p'"><span id="page" class="col-sm-2" style="position:absolute;margin-left:600px;"> <xsl:text>.....</xsl:text><xsl:value-of select="text()"/></span></xsl:when>
+</xsl:choose>
+</xsl:for-each>
+</xsl:for-each>
+</xsl:if>
+
+
+</div>
+
+
+
+<xsl:if test="marc:datafield[@tag=610]">
+<span class="results_summary">
+<span class="label">Sujet : </span>
+<xsl:for-each select="marc:datafield[@tag=610]">
+<xsl:choose>
+<xsl:when test="contains(marc:subfield[@code='a'],'(')">
+<a>
+<xsl:attribute name="href">/cgi-bin/koha/opac-search.pl?q=su,phr:
+<xsl:value-of select="marc:subfield[@code='a']"/>-->
+<xsl:value-of select="substring-before(marc:subfield[@code='a'], '(')" />
+<xsl:value-of select="substring-before(substring-after(marc:subfield[@code='a'], '('), ')')" />
+<xsl:value-of select="substring-after(marc:subfield[@code='a'], ')')" />
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='a']"/>
+</a>
+</xsl:when>
+<xsl:otherwise>
+<a>
+<xsl:attribute name="href">/cgi-bin/koha/opac-search.pl?q=su,phr:<xsl:value-of select="marc:subfield[@code='a']"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='a']"/>
+</a>
+</xsl:otherwise>
+</xsl:choose>
+<xsl:choose>
+<xsl:when test="position()=last()">
+<xsl:text> </xsl:text>
+</xsl:when>
+<xsl:otherwise>
+<xsl:text> .  </xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:for-each>
+</span>
+</xsl:if>
+
+
+<!--<xsl:if test="marc:datafield[@tag=902]">
+<span class="results_summary">
+<span class="label">Niveau de lecture :</span> 
+ <xsl:for-each select="marc:datafield[@tag=902]">
+ <xsl:value-of select="marc:subfield[@code='a']"/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text> </xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text> .  </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+ </span>
+ </xsl:if>-->
+
+<!--<xsl:if test="marc:datafield[@tag=903]">
+<span class="results_summary">
+<span class="label">Genre : </span>
+<xsl:for-each select="marc:datafield[@tag=903]">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:value-of select="marc:subfield[@code='p']"/>
+<xsl:choose>
+<xsl:when test="position()=last()">
+<xsl:text> </xsl:text>
+</xsl:when>
+<xsl:otherwise>
+<xsl:text>; </xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:for-each>
+</span>
+</xsl:if>-->
+
+<!--
+<xsl:if test="marc:datafield[@tag=464]">
+<div class="panel panel-default results_summary">
+<div class="panel-heading" style="background-color:#FAFAFA">
+Contenu :
+</div>
+<div class="panel-body" style="height:190px;overflow:auto;background-color:#FAFAFA">
+<xsl:for-each select="marc:datafield[@tag=464]">
+<p>
+<xsl:choose>
+<xsl:when test="marc:subfield[@code='u']">
+<a>
+<xsl:attribute name="href"><xsl:value-of select="marc:subfield[@code='u']"/></xsl:attribute>
+<xsl:attribute name="title"><xsl:text>play-pause</xsl:text></xsl:attribute>
+<xsl:attribute name="class"><xsl:text>sm2_button</xsl:text></xsl:attribute>
+<xsl:text>play-pause</xsl:text>
+<img id="play" width="18" height="18"><xsl:attribute name="src">/public/images/play.png</xsl:attribute></img>
+</a>
+</xsl:when>
+<xsl:otherwise>
+<img id="noplay" width="18" height="18"><xsl:attribute name="src">/public/images/noplay.png</xsl:attribute></img>
+</xsl:otherwise>
+</xsl:choose>
+<xsl:text> - </xsl:text>
+<xsl:if test="marc:subfield[@code='h']">
+<xsl:value-of select="marc:subfield[@code='h']"/><xsl:text> - </xsl:text>
+</xsl:if>
+<xsl:choose>
+<xsl:when test="marc:subfield[@code='t']"><xsl:value-of select="marc:subfield[@code='t']"/></xsl:when>
+<xsl:when test="marc:subfield[@code='z']"><xsl:value-of select="marc:subfield[@code='z']"/></xsl:when>
+<xsl:otherwise>Titre inconnu</xsl:otherwise>
+</xsl:choose>
+<xsl:if test="marc:subfield[@code='a']">
+<i>
+<xsl:for-each select="marc:subfield[@code='a']">
+<xsl:text> - </xsl:text><xsl:value-of select="."/>
+</xsl:for-each>
+</i>
+</xsl:if>
+</p>
+</xsl:for-each>
+</div>
+</div>
+</xsl:if>
+-->
+
+
+<!--Etat de collection-->
+<xsl:if test="marc:datafield[@tag=923]">
+    <dt class="prolabelxslt">État des collections</dt>
+         <xsl:for-each select="marc:datafield[@tag=923]">
+ <xsl:if test="marc:subfield[@code='r']">
+            <xsl:if test="marc:subfield[@code='b']">
+              <dd>
+              <xsl:if test="marc:subfield[@code='b']">
+                        <xsl:call-template name="RCR">
+                            <xsl:with-param name="code" select="marc:subfield[@code='b']"/>
+                        </xsl:call-template>
+                  </xsl:if>
+                      <xsl:if test="marc:subfield[@code='r']">
+                  <xsl:text> : </xsl:text>
+                  <span class="statutdispo">
+                                <xsl:value-of select="marc:subfield[@code='r']"/>
+                  </span>
+                      </xsl:if>
+              </dd>
+            </xsl:if>
+            <xsl:if test="marc:subfield[@code='W']">
+              <dd>
+                <span class="profctxslt">
+                  <xsl:text>Lacunes : </xsl:text>
+                  <xsl:value-of select="marc:subfield[@code='W']"/>
+                </span>
+              </dd>
+            </xsl:if>
+                        <xsl:if test="marc:subfield[@code='Z']">
+              <dd>
+                <span class="profctxslt">
+                  <xsl:text>Notes : </xsl:text>
+                  <xsl:value-of select="marc:subfield[@code='Z']"/>
+                </span>
+              </dd>
+            </xsl:if>
+<xsl:if test="marc:subfield[@code='a'] or marc:subfield[@code='c'] or marc:subfield[@code='d']">
+              <dd>
+                <span class="profctxslt">
+                <xsl:if test="marc:subfield[@code='a']">
+                  <xsl:text>Cote : </xsl:text>
+                  <xsl:value-of select="marc:subfield[@code='a']" />
+                </xsl:if>
+                <xsl:if test="marc:subfield[@code='c']">
+                    <xsl:choose>
+                      <xsl:when test="marc:subfield[@code='a']">
+                        <xsl:text> ; Localisation : </xsl:text>
+                      </xsl:when>
+                      <xsl:otherwise>
+                        <xsl:text>Localisation : </xsl:text>
+                      </xsl:otherwise>
+                    </xsl:choose>
+                  <xsl:value-of select="marc:subfield[@code='c']" />
+                </xsl:if>
+                <xsl:if test="marc:subfield[@code='d']">
+                    <xsl:choose>
+                      <xsl:when test="marc:subfield[@code='a'] or marc:subfield[@code='d']">
+                        <xsl:text> ; </xsl:text>
+                      </xsl:when>
+                      <xsl:otherwise>
+                      </xsl:otherwise>
+                    </xsl:choose>
+                  <xsl:value-of select="marc:subfield[@code='d']" />
+                </xsl:if>
+              </span>
+              </dd>
+            </xsl:if>
+ </xsl:if>
+         </xsl:for-each>
+                  <xsl:for-each select="marc:datafield[@tag=930]">
+                        <xsl:if test="marc:subfield[@code='z'] or marc:subfield[@code='p']">
+                        <dd>
+                       <!--<span class="profctxslt">-->
+                        <span class="profctxslt">
+                                <xsl:text>Conservation : </xsl:text>
+                                        <xsl:value-of select="marc:subfield[@code='z']" />
+                                        <xsl:text> (</xsl:text>
+                                        <xsl:value-of select="marc:subfield[@code='p']" />
+                                        <xsl:text>)</xsl:text>
+                        </span>
+                        </dd>
+                        </xsl:if>
+                  </xsl:for-each>
+</xsl:if>
+
+<xsl:if test="marc:datafield[@tag=924]">
+    <dt class="prolabelxslt">État des lacunes</dt>
+         <xsl:for-each select="marc:datafield[@tag=924]">
+ <xsl:if test="marc:subfield[@code='r']">
+            <xsl:if test="marc:subfield[@code='b']">
+              <dd>
+              <xsl:if test="marc:subfield[@code='b']">
+                        <xsl:call-template name="RCR">
+                            <xsl:with-param name="code" select="marc:subfield[@code='b']"/>
+                        </xsl:call-template>
+                  </xsl:if>
+                      <xsl:if test="marc:subfield[@code='r']">
+                  <xsl:text> : </xsl:text>
+                  <span class="statutdispo">
+                                <xsl:value-of select="marc:subfield[@code='r']"/>
+                  </span>
+                      </xsl:if>
+              </dd>
+            </xsl:if>
+            <xsl:if test="marc:subfield[@code='W']">
+              <dd>
+                <span class="profctxslt">
+                  <xsl:text>Lacunes : </xsl:text>
+                  <xsl:value-of select="marc:subfield[@code='W']"/>
+                </span>
+              </dd>
+            </xsl:if>
+                        <xsl:if test="marc:subfield[@code='Z']">
+              <dd>
+                <span class="profctxslt">
+                  <xsl:text>Notes : </xsl:text>
+                  <xsl:value-of select="marc:subfield[@code='Z']"/>
+                </span>
+              </dd>
+            </xsl:if>
+<xsl:if test="marc:subfield[@code='a'] or marc:subfield[@code='c'] or marc:subfield[@code='d']">
+              <dd>
+                <span class="profctxslt">
+                <xsl:if test="marc:subfield[@code='a']">
+                  <xsl:text>Cote : </xsl:text>
+                  <xsl:value-of select="marc:subfield[@code='a']" />
+                </xsl:if>
+                <xsl:if test="marc:subfield[@code='c']">
+                    <xsl:choose>
+                      <xsl:when test="marc:subfield[@code='a']">
+                        <xsl:text> ; Localisation : </xsl:text>
+                      </xsl:when>
+                      <xsl:otherwise>
+                        <xsl:text>Localisation : </xsl:text>
+                      </xsl:otherwise>
+                    </xsl:choose>
+                  <xsl:value-of select="marc:subfield[@code='c']" />
+                </xsl:if>
+                <xsl:if test="marc:subfield[@code='d']">
+                    <xsl:choose>
+                      <xsl:when test="marc:subfield[@code='a'] or marc:subfield[@code='d']">
+                        <xsl:text> ; </xsl:text>
+                      </xsl:when>
+                      <xsl:otherwise>
+                      </xsl:otherwise>
+                    </xsl:choose>
+                  <xsl:value-of select="marc:subfield[@code='d']" />
+                </xsl:if>
+              </span>
+              </dd>
+            </xsl:if>
+ </xsl:if>
+         </xsl:for-each>
+                  <xsl:for-each select="marc:datafield[@tag=930]">
+                        <xsl:if test="marc:subfield[@code='z'] or marc:subfield[@code='p']">
+                        <dd>
+                       <!--<span class="profctxslt">-->
+                        <span class="profctxslt">
+                                <xsl:text>Conservation : </xsl:text>
+                                        <xsl:value-of select="marc:subfield[@code='z']" />
+                                        <xsl:text> (</xsl:text>
+                                        <xsl:value-of select="marc:subfield[@code='p']" />
+                                        <xsl:text>)</xsl:text>
+                        </span>
+                        </dd>
+                        </xsl:if>
+                  </xsl:for-each>
+</xsl:if>
+
+
+
+
+
+
+<xsl:for-each select="marc:datafield[@tag=600]">
+<span class="results_summary">
+<span class="label">Sujet - Nom de personne : </span>
+<xsl:if test="marc:subfield[@code='a']">
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text>+</xsl:text> <xsl:if test="marc:subfield[@code='b']!=''"><xsl:value-of select="marc:subfield[@code='b']"/></xsl:if>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='a']"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='b']">
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='b']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='d']">
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='c']">
+<xsl:text>, </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='c']"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='f']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='f']"/>
+<xsl:text>) </xsl:text>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='x']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:element>
+<xsl:if test="marc:subfield[@code='x'][2]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][2]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='x'][3]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][3]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][3]"/></xsl:element>
+</xsl:if>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='y']">
+<xsl:text> -- </xsl:text>
+<xsl:value-of select="marc:subfield[@code='y']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='z']">
+<xsl:text> -- </xsl:text>
+<xsl:value-of select="marc:subfield[@code='z']"/>
+</xsl:if>
+<xsl:text> | </xsl:text>
+<!-- recherche sur tous les mots-->
+<xsl:element name="a">
+<xsl:attribute name="href">/cgi-bin/koha/opac-search.pl?idx=su&amp;q=
+<xsl:choose>
+        <xsl:when test="contains(marc:subfield[@code='a'],'(')">
+          <xsl:value-of select="substring-before(marc:subfield[@code='a'], '(')" />
+          <xsl:value-of select="substring-before(substring-after(marc:subfield[@code='a'], '('), ')')" />
+          <xsl:value-of select="substring-after(marc:subfield[@code='a'], ')')" />
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="marc:subfield[@code='a']" />
+        </xsl:otherwise>
+      </xsl:choose> 
+
+<xsl:if test="marc:subfield[@code='b'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='b']!=''"><xsl:value-of select="marc:subfield[@code='b']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='c'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='c']!=''"><xsl:value-of select="marc:subfield[@code='c']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='d'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='d']!=''"><xsl:value-of select="marc:subfield[@code='d']"/></xsl:if><xsl:if test="marc:subfield[@code='x'][1] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][1]!=''"><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][2] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][2]!=''"><xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][3] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][3]!=''"><xsl:value-of select="marc:subfield[@code='x'][3]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='z'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='z']!=''"><xsl:value-of select="marc:subfield[@code='z']"/></xsl:if>
+</xsl:attribute>
+<xsl:attribute name="title">Lancer une recherche sur les mots sujet</xsl:attribute>
+<i class="fa fa-search"></i>
+</xsl:element>
+</span>
+</xsl:for-each>
+
+
+<xsl:for-each select="marc:datafield[@tag=601]">
+<span class="results_summary">
+<span class="label">Sujet - Collectivité : </span>
+<xsl:if test="marc:subfield[@code='a']">
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='a']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='a']"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='b']">
+<xsl:text>. </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='b'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='b'][1]"/></xsl:element>
+<xsl:if test="marc:subfield[@code='b'][2]">
+<xsl:text>. </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='b'][2]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='b'][2]"/></xsl:element>
+</xsl:if>
+
+<xsl:if test="marc:subfield[@code='b'][3]">
+<xsl:text>. </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='b'][3]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='b'][3]"/></xsl:element>
+</xsl:if>
+
+</xsl:if>
+<xsl:if test="marc:subfield[@code='c']">
+<xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+ </xsl:if>
+
+<xsl:choose>
+<xsl:when test="(marc:subfield[@code='d']) and (marc:subfield[@code='f']) and (marc:subfield[@code='e'])">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:text> ; </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='f']"/>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='d']) and (marc:subfield[@code='f'])">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:text> ; </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='f']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='d']) and (marc:subfield[@code='e'])">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:text> ; </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='e']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='e']) and (marc:subfield[@code='f'])">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='f']"/>
+<xsl:text> ; </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='e']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+<xsl:when test="marc:subfield[@code='d']">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+</xsl:choose>
+
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='x']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:element>
+<xsl:if test="marc:subfield[@code='x'][2]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][2]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='x'][3]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][3]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][3]"/></xsl:element></xsl:if>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='y']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='y']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='y']"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='z']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='z']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='z']"/></xsl:element>
+</xsl:if>
+<xsl:text> | </xsl:text>
+<!-- recherche sur tous les mots -->
+<xsl:element name="a">
+<xsl:attribute name="href">/cgi-bin/koha/opac-search.pl?idx=su&amp;q=
+<xsl:choose>
+        <xsl:when test="contains(marc:subfield[@code='a'],'(')">
+          <xsl:value-of select="substring-before(marc:subfield[@code='a'], '(')" />
+          <xsl:value-of select="substring-before(substring-after(marc:subfield[@code='a'], '('), ')')" />
+          <xsl:value-of select="substring-after(marc:subfield[@code='a'], ')')" />
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="marc:subfield[@code='a']" />
+        </xsl:otherwise>
+      </xsl:choose> 
+<xsl:if test="marc:subfield[@code='b'][1]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='b'][1]!=''"><xsl:value-of select="marc:subfield[@code='b'][1]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='b'][2]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='b'][2]!=''"><xsl:value-of select="marc:subfield[@code='b'][2]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='b'][3]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='b'][3]!=''"><xsl:value-of select="marc:subfield[@code='b'][3]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][1]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][1]!=''"><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][2]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][2]!=''"><xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][3]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][3]!=''"><xsl:value-of select="marc:subfield[@code='x'][3]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='y'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='y']!=''"><xsl:value-of select="marc:subfield[@code='y']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='z'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='z']!=''"><xsl:value-of select="marc:subfield[@code='z']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='j'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='j']!=''"><xsl:value-of select="marc:subfield[@code='j']"/></xsl:if>
+</xsl:attribute>
+<xsl:attribute name="title">Lancer une recherche sur les mots sujet</xsl:attribute>
+<i class="fa fa-search"></i>
+</xsl:element>
+</span>
+</xsl:for-each>
+
+
+<xsl:for-each select="marc:datafield[@tag=602]">
+<span class="results_summary">
+<span class="label">Sujet –  Nom de famille : </span>
+<xsl:if test="marc:subfield[@code='a']">
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='a']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='a']"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='b']">
+<xsl:text>. </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='b'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='b'][1]"/></xsl:element>
+<xsl:if test="marc:subfield[@code='b'][2]">
+<xsl:text>. </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='b'][2]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='b'][2]"/></xsl:element>
+</xsl:if>
+
+<xsl:if test="marc:subfield[@code='b'][3]">
+<xsl:text>. </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='b'][3]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='b'][3]"/></xsl:element>
+</xsl:if>
+
+       </xsl:if>
+<xsl:if test="marc:subfield[@code='c']">
+<xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+ </xsl:if>
+
+<xsl:choose>
+<xsl:when test="(marc:subfield[@code='d']) and (marc:subfield[@code='f']) and (marc:subfield[@code='e'])">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:text> ; </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='f']"/>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='d']) and (marc:subfield[@code='f'])">
+ <xsl:text> ( </xsl:text>
+</xsl:when>
+<xsl:when test="marc:subfield[@code='d']">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+</xsl:choose>
+
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='t']">
+<xsl:text> -- </xsl:text>
+<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='x']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:element>
+<xsl:if test="marc:subfield[@code='x'][2]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][2]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='x'][3]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][3]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][3]"/></xsl:element></xsl:if>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='y']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='y']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='y']"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='z']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='z']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='z']"/></xsl:element>
+</xsl:if>
+<xsl:text> | </xsl:text>
+<!-- recherche sur tous les mots -->
+<xsl:element name="a">
+<xsl:attribute name="href">/cgi-bin/koha/opac-search.pl?idx=su&amp;q=
+<xsl:choose>
+        <xsl:when test="contains(marc:subfield[@code='a'],'(')">
+          <xsl:value-of select="substring-before(marc:subfield[@code='a'], '(')" />
+          <xsl:value-of select="substring-before(substring-after(marc:subfield[@code='a'], '('), ')')" />
+          <xsl:value-of select="substring-after(marc:subfield[@code='a'], ')')" />
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="marc:subfield[@code='a']" />
+        </xsl:otherwise>
+      </xsl:choose> 
+<xsl:if test="marc:subfield[@code='b'][1]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='b'][1]!=''"><xsl:value-of select="marc:subfield[@code='b'][1]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='b'][2]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='b'][2]!=''"><xsl:value-of select="marc:subfield[@code='b'][2]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='b'][3]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='b'][3]!=''"><xsl:value-of select="marc:subfield[@code='b'][3]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][1]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][1]!=''"><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][2]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][2]!=''"><xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][3]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][3]!=''"><xsl:value-of select="marc:subfield[@code='x'][3]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='t']!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='t']!=''"><xsl:value-of select="marc:subfield[@code='t']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='y'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='y']!=''"><xsl:value-of select="marc:subfield[@code='y']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='z'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='z']!=''"><xsl:value-of select="marc:subfield[@code='z']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='j'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='j']!=''"><xsl:value-of select="marc:subfield[@code='j']"/></xsl:if>
+</xsl:attribute>
+<xsl:attribute name="title">Lancer une recherche sur les mots sujet</xsl:attribute>
+<i class="fa fa-search"></i>
+</xsl:element>
+</span>
+</xsl:for-each>
+
+
+<xsl:for-each select="marc:datafield[@tag=604]">
+<span class="results_summary">
+<span class="label">Sujet –  Auteur/Titre : </span>
+<xsl:if test="marc:subfield[@code='a']">
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='a']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='a']"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='b']">
+<xsl:text>. </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='b'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='b'][1]"/></xsl:element>
+<xsl:if test="marc:subfield[@code='b'][2]">
+<xsl:text>. </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='b'][2]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='b'][2]"/></xsl:element>
+</xsl:if>
+
+<xsl:if test="marc:subfield[@code='b'][3]">
+<xsl:text>. </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='b'][3]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='b'][3]"/></xsl:element>
+</xsl:if>
+
+       </xsl:if>
+<xsl:if test="marc:subfield[@code='c']">
+<xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+ </xsl:if>
+
+<xsl:choose>
+<xsl:when test="(marc:subfield[@code='d']) and (marc:subfield[@code='f']) and (marc:subfield[@code='e'])">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:text> ; </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='f']"/>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='d']) and (marc:subfield[@code='f'])">
+ <xsl:text> ( </xsl:text>
+</xsl:when>
+<xsl:when test="marc:subfield[@code='d']">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+</xsl:choose>
+
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='t']">
+<xsl:text> -- </xsl:text>
+<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='x']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:element>
+<xsl:if test="marc:subfield[@code='x'][2]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][2]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='x'][3]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][3]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][3]"/></xsl:element></xsl:if>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='y']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='y']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='y']"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='z']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='z']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='z']"/></xsl:element>
+</xsl:if>
+<xsl:text> | </xsl:text>
+<!-- recherche sur tous les mots -->
+<xsl:element name="a">
+<xsl:attribute name="href">/cgi-bin/koha/opac-search.pl?idx=su&amp;q=
+<xsl:choose>
+        <xsl:when test="contains(marc:subfield[@code='a'],'(')">
+          <xsl:value-of select="substring-before(marc:subfield[@code='a'], '(')" />
+          <xsl:value-of select="substring-before(substring-after(marc:subfield[@code='a'], '('), ')')" />
+          <xsl:value-of select="substring-after(marc:subfield[@code='a'], ')')" />
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="marc:subfield[@code='a']" />
+        </xsl:otherwise>
+      </xsl:choose> 
+<xsl:if test="marc:subfield[@code='b'][1]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='b'][1]!=''"><xsl:value-of select="marc:subfield[@code='b'][1]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][1]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][1]!=''"><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][2]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][2]!=''"><xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][3]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][3]!=''"><xsl:value-of select="marc:subfield[@code='x'][3]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='t']!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='t']!=''"><xsl:value-of select="marc:subfield[@code='t']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='y'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='y']!=''"><xsl:value-of select="marc:subfield[@code='y']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='z'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='z']!=''"><xsl:value-of select="marc:subfield[@code='z']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='j'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='j']!=''"><xsl:value-of select="marc:subfield[@code='j']"/></xsl:if>
+</xsl:attribute>
+<xsl:attribute name="title">Lancer une recherche sur les mots sujet</xsl:attribute>
+<i class="fa fa-search"></i>
+</xsl:element>
+</span>
+</xsl:for-each>
+
+
+<xsl:for-each select="marc:datafield[@tag=605]">
+<span class="results_summary">
+<span class="label">Sujet –  Titre uniforme : </span>
+<xsl:if test="marc:subfield[@code='a']">
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='a']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='a']"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='b']">
+<xsl:text>. </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='b'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='b'][1]"/></xsl:element>
+<xsl:if test="marc:subfield[@code='b'][2]">
+<xsl:text>. </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='b'][2]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='b'][2]"/></xsl:element>
+</xsl:if>
+
+<xsl:if test="marc:subfield[@code='b'][3]">
+<xsl:text>. </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='b'][3]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='b'][3]"/></xsl:element>
+</xsl:if>
+
+       </xsl:if>
+<xsl:if test="marc:subfield[@code='c']">
+<xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+ </xsl:if>
+
+<xsl:choose>
+<xsl:when test="(marc:subfield[@code='d']) and (marc:subfield[@code='f']) and (marc:subfield[@code='e'])">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:text> ; </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='f']"/>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='d']) and (marc:subfield[@code='f'])">
+ <xsl:text> ( </xsl:text>
+</xsl:when>
+<xsl:when test="marc:subfield[@code='d']">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+</xsl:choose>
+
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='t']">
+<xsl:text> -- </xsl:text>
+<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='x']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:element>
+<xsl:if test="marc:subfield[@code='x'][2]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][2]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='x'][3]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][3]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][3]"/></xsl:element></xsl:if>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='y']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='y']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='y']"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='z']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='z']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='z']"/></xsl:element>
+</xsl:if>
+<xsl:text> | </xsl:text>
+<!-- recherche sur tous les mots -->
+<xsl:element name="a">
+<xsl:attribute name="href">/cgi-bin/koha/opac-search.pl?idx=su&amp;q=
+<xsl:choose>
+        <xsl:when test="contains(marc:subfield[@code='a'],'(')">
+          <xsl:value-of select="substring-before(marc:subfield[@code='a'], '(')" />
+          <xsl:value-of select="substring-before(substring-after(marc:subfield[@code='a'], '('), ')')" />
+          <xsl:value-of select="substring-after(marc:subfield[@code='a'], ')')" />
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="marc:subfield[@code='a']" />
+        </xsl:otherwise>
+      </xsl:choose> 
+<xsl:if test="marc:subfield[@code='b'][1]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='b'][1]!=''"><xsl:value-of select="marc:subfield[@code='b'][1]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][1]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][1]!=''"><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][2]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][2]!=''"><xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][3]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][3]!=''"><xsl:value-of select="marc:subfield[@code='x'][3]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='t']!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='t']!=''"><xsl:value-of select="marc:subfield[@code='t']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='y'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='y']!=''"><xsl:value-of select="marc:subfield[@code='y']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='z'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='z']!=''"><xsl:value-of select="marc:subfield[@code='z']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='j'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='j']!=''"><xsl:value-of select="marc:subfield[@code='j']"/></xsl:if>
+</xsl:attribute>
+<xsl:attribute name="title">Lancer une recherche sur les mots sujet</xsl:attribute>
+<i class="fa fa-search"></i>
+</xsl:element>
+</span>
+</xsl:for-each>
+
+
+
+
+<xsl:for-each select="marc:datafield[@tag=606]">
+<span class="results_summary">
+<span class="label">Sujets - Nom commun : </span>
+<xsl:if test="marc:subfield[@code='a']">
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='a']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='a']"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='j']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='j'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='j'][1]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='x']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:element>
+<xsl:if test="marc:subfield[@code='x'][2]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][2]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='x'][3]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][3]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][3]"/></xsl:element>
+</xsl:if>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='y']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='y'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='y'][1]"/></xsl:element>
+<xsl:if test="marc:subfield[@code='y'][2]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='y'][2]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='y'][2]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='y'][3]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='y'][3]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='y'][3]"/></xsl:element>
+</xsl:if>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='z']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='z']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='z']"/></xsl:element>
+</xsl:if>
+<xsl:text> | </xsl:text>
+<!-- recherche sur tous les mots -->
+<xsl:element name="a">
+<xsl:attribute name="href">/cgi-bin/koha/opac-search.pl?idx=su&amp;q=
+<xsl:choose>
+        <xsl:when test="contains(marc:subfield[@code='a'],'(')">
+          <xsl:value-of select="substring-before(marc:subfield[@code='a'], '(')" />
+          <xsl:value-of select="substring-before(substring-after(marc:subfield[@code='a'], '('), ')')" />
+          <xsl:value-of select="substring-after(marc:subfield[@code='a'], ')')" />
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="marc:subfield[@code='a']" />
+        </xsl:otherwise>
+      </xsl:choose> 
+<xsl:if test="marc:subfield[@code='x'][1]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][1]!=''"><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][2]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][2]!=''"> <xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='y'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='y']!=''"><xsl:value-of select="marc:subfield[@code='y']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='z'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='z']!=''"><xsl:value-of select="marc:subfield[@code='z']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='j'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='j']!=''"><xsl:value-of select="marc:subfield[@code='j']"/></xsl:if>
+</xsl:attribute>
+<xsl:attribute name="title">Lancer une recherche sur les mots sujet</xsl:attribute>
+<i class="fa fa-search"></i>
+</xsl:element>
+</span>
+</xsl:for-each>
+
+
+<xsl:for-each select="marc:datafield[@tag=607]">
+<span class="results_summary">
+<span class="label">Sujet - Nom géographique : </span>
+<xsl:if test="marc:subfield[@code='a']">
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='a']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='a']"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='x']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:element>
+<xsl:if test="marc:subfield[@code='x'][2]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][2]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='x'][3]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][3]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][3]"/></xsl:element>
+</xsl:if>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='y']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='y'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='y'][1]"/></xsl:element>
+<xsl:if test="marc:subfield[@code='y'][2]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='y'][2]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='y'][2]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='y'][3]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='y'][3]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='y'][3]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='y'][4]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='y'][4]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='y'][4]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='y'][5]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='y'][5]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='y'][5]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='y'][6]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='y'][6]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='y'][6]"/></xsl:element>
+</xsl:if>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='z']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='z']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='z']"/></xsl:element>
+</xsl:if>
+<xsl:text> | </xsl:text>
+<!-- recherche sur tous les mots -->
+<xsl:element name="a">
+<xsl:attribute name="href">/cgi-bin/koha/opac-search.pl?idx=su&amp;q=
+<xsl:choose>
+        <xsl:when test="contains(marc:subfield[@code='a'],'(')">
+          <xsl:value-of select="substring-before(marc:subfield[@code='a'], '(')" />
+          <xsl:value-of select="substring-before(substring-after(marc:subfield[@code='a'], '('), ')')" />
+          <xsl:value-of select="substring-after(marc:subfield[@code='a'], ')')" />
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="marc:subfield[@code='a']" />
+        </xsl:otherwise>
+      </xsl:choose> 
+<xsl:if test="marc:subfield[@code='x'][1]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][1]!=''"><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][2]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][2]!=''"><xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][3]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][3]!=''"><xsl:value-of select="marc:subfield[@code='x'][3]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='y'][1] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='y'][1] !=''"><xsl:value-of select="marc:subfield[@code='y'][1]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='y'][2] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='y'][2] !=''"><xsl:value-of select="marc:subfield[@code='y'][2]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='y'][3] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='y'][3] !=''"><xsl:value-of select="marc:subfield[@code='y'][3]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='z'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='z']!=''"><xsl:value-of select="marc:subfield[@code='z']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='j'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='j']!=''"><xsl:value-of select="marc:subfield[@code='j']"/></xsl:if>
+</xsl:attribute>
+<xsl:attribute name="title">Lancer une recherche sur les mots sujet</xsl:attribute>
+<i class="fa fa-search"></i>
+</xsl:element>
+</span> 
+</xsl:for-each>
+
+
+<xsl:for-each select="marc:datafield[@tag=608]">
+<span class="results_summary">
+<span class="label">Sujet - Forme, genre, caractéristiques physiques : </span>
+<xsl:if test="marc:subfield[@code='a']">
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='a']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='a']"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='b']">
+<xsl:text>. </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='b'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='b'][1]"/></xsl:element>
+<xsl:if test="marc:subfield[@code='b'][2]">
+<xsl:text>. </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='b'][2]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='b'][2]"/></xsl:element>
+</xsl:if>
+
+<xsl:if test="marc:subfield[@code='b'][3]">
+<xsl:text>. </xsl:text>
+<xsl:element name="a">
+        <xsl:attribute name="href">
+     /cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='b'][3]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='b'][3]"/></xsl:element>
+</xsl:if>
+
+       </xsl:if>
+<xsl:if test="marc:subfield[@code='c']">
+<xsl:text>. </xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+ </xsl:if>
+
+<xsl:choose>
+<xsl:when test="(marc:subfield[@code='d']) and (marc:subfield[@code='f']) and (marc:subfield[@code='e'])">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:text> ; </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='f']"/>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='d']) and (marc:subfield[@code='f'])">
+ <xsl:text> ( </xsl:text>
+</xsl:when>
+<xsl:when test="marc:subfield[@code='d']">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+</xsl:choose>
+
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='t']">
+<xsl:text> -- </xsl:text>
+<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='x']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:element>
+<xsl:if test="marc:subfield[@code='x'][2]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][2]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='x'][3]">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='x'][3]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][3]"/></xsl:element></xsl:if>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='y']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='y']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='y']"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='a'] and  marc:subfield[@code='z']">
+<xsl:text> -- </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=su,phr&amp;q=<xsl:value-of select="marc:subfield[@code='z']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='z']"/></xsl:element>
+</xsl:if>
+<xsl:text> | </xsl:text>
+<!-- recherche sur tous les mots -->
+<xsl:element name="a">
+<xsl:attribute name="href">/cgi-bin/koha/opac-search.pl?idx=su&amp;q=
+<xsl:choose>
+        <xsl:when test="contains(marc:subfield[@code='a'],'(')">
+          <xsl:value-of select="substring-before(marc:subfield[@code='a'], '(')" />
+          <xsl:value-of select="substring-before(substring-after(marc:subfield[@code='a'], '('), ')')" />
+          <xsl:value-of select="substring-after(marc:subfield[@code='a'], ')')" />
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="marc:subfield[@code='a']" />
+        </xsl:otherwise>
+      </xsl:choose> 
+<xsl:if test="marc:subfield[@code='b'][1]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='b'][1]!=''"><xsl:value-of select="marc:subfield[@code='b'][1]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][1]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][1]!=''"><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][2]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][2]!=''"><xsl:value-of select="marc:subfield[@code='x'][2]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='x'][3]!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='x'][3]!=''"><xsl:value-of select="marc:subfield[@code='x'][3]"/></xsl:if>
+<xsl:if test="marc:subfield[@code='t']!=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='t']!=''"><xsl:value-of select="marc:subfield[@code='t']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='y'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='y']!=''"><xsl:value-of select="marc:subfield[@code='y']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='z'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='z']!=''"><xsl:value-of select="marc:subfield[@code='z']"/></xsl:if>
+<xsl:if test="marc:subfield[@code='j'] !=''"><xsl:text>+</xsl:text></xsl:if> <xsl:if test="marc:subfield[@code='j']!=''"><xsl:value-of select="marc:subfield[@code='j']"/></xsl:if>
+</xsl:attribute>
+<xsl:attribute name="title">Lancer une recherche sur les mots sujet</xsl:attribute>
+<i class="fa fa-search"></i>
+</xsl:element>
+</span>
+</xsl:for-each>
+
+
+
+ <xsl:call-template name="tag_subject">
+ <xsl:with-param name="tag">615</xsl:with-param>
+ <xsl:with-param name="label">Catégorie de sujet</xsl:with-param>
+ </xsl:call-template>
+
+ <xsl:call-template name="tag_subject">
+ <xsl:with-param name="tag">616</xsl:with-param>
+ <xsl:with-param name="label">Marque commerciale</xsl:with-param>
+ </xsl:call-template>
+
+
+<xsl:if test="marc:datafield[@tag=856]/marc:subfield[@code='u']">
+<span class="results_summary">
+<span class="label">Ressources en ligne : </span>
+<xsl:for-each select="marc:datafield[@tag=856]">
+<xsl:variable name="url" select="substring-before(marc:subfield[@code='u'], '//')"/>
+<xsl:if test="contains($url,'http:') or contains($url,'https:')">
+<a>
+<xsl:attribute name="href">
+<xsl:value-of select="marc:subfield[@code='u']"/>
+</xsl:attribute>
+<xsl:choose>
+<xsl:when test="marc:subfield[@code='y' or @code='3' or @code='z']">
+<xsl:call-template name="subfieldSelect">
+<xsl:with-param name="codes">y3z</xsl:with-param>
+</xsl:call-template>
+</xsl:when>
+<xsl:when test="not(marc:subfield[@code='y']) and not(marc:subfield[@code='3']) and not(marc:subfield[@code='z'])">
+Cliquer ici
+</xsl:when>
+</xsl:choose>
+</a>
+</xsl:if>
+<xsl:if test="not(contains($url,'http:')) and not(contains($url,'https:'))">
+<a>
+<xsl:attribute name="href">
+http://<xsl:value-of select="marc:subfield[@code='u']"/>
+</xsl:attribute>
+<xsl:choose>
+<xsl:when test="marc:subfield[@code='y' or @code='3' or @code='z']">
+<xsl:call-template name="subfieldSelect">
+<xsl:with-param name="codes">y3z</xsl:with-param>
+</xsl:call-template>
+</xsl:when>
+<xsl:when test="not(marc:subfield[@code='y']) and not(marc:subfield[@code='3']) and not(marc:subfield[@code='z'])">
+Cliquer ici
+</xsl:when>
+</xsl:choose>
+</a>
+</xsl:if>
+<xsl:choose>
+<xsl:when test="position()=last()"/>
+<xsl:otherwise> | </xsl:otherwise>
+</xsl:choose>
+</xsl:for-each>
+</span>
+</xsl:if>
+
+<!--
+<xsl:if test="marc:datafield[@tag=901]">
+
+ <span class="results_summary">
+<span class="label">Genre : </span>
+ <xsl:for-each select="marc:datafield[@tag=901]">
+ <xsl:for-each select="marc:subfield">
+ <xsl:value-of select="text()"/>
+ <xsl:choose>
+ <xsl:when test="position()=last()">
+ <xsl:text>.</xsl:text>
+ </xsl:when>
+ <xsl:otherwise><xsl:text>, </xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+ </xsl:for-each>
+ </span>
+ </xsl:if>
+-->
+
+ <!-- 780 -->
+ <xsl:if test="marc:datafield[@tag=780]">
+ <xsl:for-each select="marc:datafield[@tag=780]">
+ <li>
+ <xsl:choose>
+ <xsl:when test="@ind2=0">
+ <strong>Continue:</strong>
+ </xsl:when>
+ <xsl:when test="@ind2=1">
+ <strong>Continue en partie:</strong>
+ </xsl:when>
+ <xsl:when test="@ind2=2">
+ <strong>Remplace :</strong>
+ </xsl:when>
+ <xsl:when test="@ind2=3">
+ <strong>Remplace partiellement :</strong>
+ </xsl:when>
+ <xsl:when test="@ind2=4">
+ <strong>Formé par la réunion de ... et: ...</strong>
+ </xsl:when>
+ <xsl:when test="@ind2=5">
+ <strong>Absorbé:</strong>
+ </xsl:when>
+ <xsl:when test="@ind2=6">
+ <strong>Absorbé en partie:</strong>
+ </xsl:when>
+ <xsl:when test="@ind2=7">
+ <strong>Séparé de :</strong>
+ </xsl:when>
+ </xsl:choose>
+
+ <xsl:variable name="f780">
+ <xsl:call-template name="subfieldSelect">
+ <xsl:with-param name="codes">à</xsl:with-param>
+ </xsl:call-template>
+ </xsl:variable>
+ <a><xsl:attribute name="href">/cgi-bin/koha/opac-search.pl?q=<xsl:value-of select="translate($f780, '()', '')"/></xsl:attribute>
+ <xsl:value-of select="translate($f780, '()', '')"/>
+ </a>
+ </li>
+
+ <xsl:choose>
+ <xsl:when test="@ind1=0">
+ <li><xsl:value-of select="marc:subfield[@code='n']"/></li>
+ </xsl:when>
+ </xsl:choose>
+
+ </xsl:for-each>
+ </xsl:if>
+
+ <!-- 785 -->
+ <xsl:if test="marc:datafield[@tag=785]">
+ <xsl:for-each select="marc:datafield[@tag=785]">
+ <li>
+ <xsl:choose>
+ <xsl:when test="@ind2=0">
+ <strong>Continué par :</strong>
+ </xsl:when>
+ <xsl:when test="@ind2=1">
+ <strong>Continué partiellement par :</strong>
+ </xsl:when>
+ <xsl:when test="@ind2=2">
+ <strong>Remplacé par :</strong>
+ </xsl:when>
+ <xsl:when test="@ind2=3">
+ <strong>Partiellement remplacé par :</strong>
+ </xsl:when>
+ <xsl:when test="@ind2=4">
+ <strong>Absorbé par:</strong>
+ </xsl:when>
+ <xsl:when test="@ind2=5">
+ <strong>Absorbé partiellement par:</strong>
+ </xsl:when>
+ <xsl:when test="@ind2=6">
+ <strong>Eclater de ... à ... :</strong>
+ </xsl:when>
+ <xsl:when test="@ind2=7">
+ <strong>Fusionné avec ... pour former ...</strong>
+ </xsl:when>
+ <xsl:when test="@ind2=8">
+ <strong>Redevient:</strong>
+ </xsl:when>
+ </xsl:choose>
+ <xsl:variable name="f785">
+ <xsl:call-template name="subfieldSelect">
+ <xsl:with-param name="codes">à</xsl:with-param>
+ </xsl:call-template>
+ </xsl:variable>
+
+ <a><xsl:attribute name="href">/cgi-bin/koha/opac-search.pl?q=<xsl:value-of select="translate($f785, '()', '')"/></xsl:attribute>
+ <xsl:value-of select="translate($f785, '()', '')"/>
+ </a>
+
+ </li>
+ </xsl:for-each>
+ </xsl:if>
+
+ </xsl:template>
+
+ <xsl:template name="nameABCDQ">
+ <xsl:call-template name="chopPunctuation">
+ <xsl:with-param name="chopString">
+ <xsl:call-template name="subfieldSelect">
+ <xsl:with-param name="codes">aq</xsl:with-param>
+ </xsl:call-template>
+ </xsl:with-param>
+ <xsl:with-param name="punctuation">
+ <xsl:text>:,;/ </xsl:text>
+ </xsl:with-param>
+ </xsl:call-template>
+ <xsl:call-template name="termsOfAddress"/>
+ </xsl:template>
+
+ <xsl:template name="nameABCDN">
+ <xsl:for-each select="marc:subfield[@code='a']">
+ <xsl:call-template name="chopPunctuation">
+ <xsl:with-param name="chopString" select="."/>
+ </xsl:call-template>
+ </xsl:for-each>
+ <xsl:for-each select="marc:subfield[@code='b']">
+ <xsl:value-of select="."/>
+ </xsl:for-each>
+ <xsl:if test="marc:subfield[@code='c'] or marc:subfield[@code='d'] or marc:subfield[@code='n']">
+ <xsl:call-template name="subfieldSelect">
+ <xsl:with-param name="codes">cdn</xsl:with-param>
+ </xsl:call-template>
+ </xsl:if>
+ </xsl:template>
+
+ <xsl:template name="nameACDEQ">
+ <xsl:call-template name="subfieldSelect">
+ <xsl:with-param name="codes">acdeq</xsl:with-param>
+ </xsl:call-template>
+ </xsl:template>
+ <xsl:template name="termsOfAddress">
+ <xsl:if test="marc:subfield[@code='b' or @code='c']">
+ <xsl:call-template name="chopPunctuation">
+ <xsl:with-param name="chopString">
+ <xsl:call-template name="subfieldSelect">
+ <xsl:with-param name="codes">bc</xsl:with-param>
+ </xsl:call-template>
+ </xsl:with-param>
+ </xsl:call-template>
+ </xsl:if>
+ </xsl:template>
+
+ <xsl:template name="part">
+ <xsl:variable name="partNumber">
+ <xsl:call-template name="specialSubfieldSelect">
+ <xsl:with-param name="axis">n</xsl:with-param>
+ <xsl:with-param name="anyCodes">n</xsl:with-param>
+ <xsl:with-param name="afterCodes">fghkdlmor</xsl:with-param>
+ </xsl:call-template>
+ </xsl:variable>
+ <xsl:variable name="partName">
+ <xsl:call-template name="specialSubfieldSelect">
+ <xsl:with-param name="axis">p</xsl:with-param>
+ <xsl:with-param name="anyCodes">p</xsl:with-param>
+ <xsl:with-param name="afterCodes">fghkdlmor</xsl:with-param>
+ </xsl:call-template>
+ </xsl:variable>
+ <xsl:if test="string-length(normalize-space($partNumber))">
+ <xsl:call-template name="chopPunctuation">
+ <xsl:with-param name="chopString" select="$partNumber"/>
+ </xsl:call-template>
+ </xsl:if>
+ <xsl:if test="string-length(normalize-space($partName))">
+ <xsl:call-template name="chopPunctuation">
+ <xsl:with-param name="chopString" select="$partName"/>
+ </xsl:call-template>
+ </xsl:if>
+ </xsl:template>
+
+ <xsl:template name="specialSubfieldSelect">
+ <xsl:param name="anyCodes"/>
+ <xsl:param name="axis"/>
+ <xsl:param name="beforeCodes"/>
+ <xsl:param name="afterCodes"/>
+ <xsl:variable name="str">
+ <xsl:for-each select="marc:subfield">
+ <xsl:if test="contains($anyCodes, @code)      or (contains($beforeCodes,@code) and following-sibling::marc:subfield[@code=$axis])      or (contains($afterCodes,@code) and preceding-sibling::marc:subfield[@code=$axis])">
+ <xsl:value-of select="text()"/>
+ <xsl:text> </xsl:text>
+ </xsl:if>
+ </xsl:for-each>
+ </xsl:variable>
+ <xsl:value-of select="substring($str,1,string-length($str)-1)"/>
+ </xsl:template>
+
+</xsl:stylesheet>

--- a/biblibre/opac/fr-FR/UNIMARCslim2OPACResults.xsl
+++ b/biblibre/opac/fr-FR/UNIMARCslim2OPACResults.xsl
@@ -1,0 +1,568 @@
+<xsl:stylesheet version="1.0"
+  xmlns:marc="http://www.loc.gov/MARC21/slim"
+  xmlns:items="http://www.koha-community.org/items"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  exclude-result-prefixes="marc items">
+
+<xsl:import href="UNIMARCslimUtils.xsl"/>
+<xsl:output method = "html" indent="yes" omit-xml-declaration = "yes" encoding="UTF-8"/>
+<xsl:key name="item-by-status" match="items:item" use="items:status"/>
+<xsl:key name="item-by-status-and-branch-home" match="items:item" use="concat(items:status, ' ', items:homebranch)"/>
+<xsl:key name="item-by-status-and-branch-holding" match="items:item" use="concat(items:status, ' ', items:holdingbranch)"/>
+
+<xsl:template match="/">
+<xsl:apply-templates/>
+</xsl:template>
+
+<xsl:template match="marc:record">
+<xsl:variable name="leader" select="marc:leader"/>
+<xsl:variable name="leader6" select="substring($leader,7,1)"/>
+<xsl:variable name="leader7" select="substring($leader,8,1)"/>
+<xsl:variable name="biblionumber" select="marc:controlfield[@tag=001]"/>
+<xsl:variable name="isbn" select="marc:datafield[@tag=010]/marc:subfield[@code='a']"/>
+<xsl:variable name="OPACResultsLibrary" select="marc:sysprefs/marc:syspref[@name='OPACResultsLibrary']"/>
+<xsl:variable name="BiblioDefaultView" select="marc:sysprefs/marc:syspref[@name='BiblioDefaultView']"/>
+<xsl:variable name="hidelostitems" select="marc:sysprefs/marc:syspref[@name='hidelostitems']"/>
+<xsl:variable name="singleBranchMode" select="marc:sysprefs/marc:syspref[@name='singleBranchMode']"/>
+<xsl:variable name="OPACURLOpenInNewWindow" select="marc:sysprefs/marc:syspref[@name='OPACURLOpenInNewWindow']"/>
+<xsl:variable name="type_doc" select="marc:datafield[@tag=099]/marc:subfield[@code='t']"/>
+
+<xsl:if test="marc:datafield[@tag=200]">
+<!--Nouveaute-->
+<xsl:call-template name="nouveaute" />
+<xsl:for-each select="marc:datafield[@tag=200]">
+<xsl:call-template name="addClassRtl" />
+<xsl:for-each select="marc:subfield">
+<xsl:choose>
+<xsl:when test="@code='a'">
+<xsl:variable name="title" select="."/>
+<xsl:variable name="ntitle"
+select="translate($title, '&#x0088;&#x0089;&#x0098;&#x009C;','')"/>
+<a>
+<xsl:attribute name="href">
+<xsl:call-template name="buildBiblioDefaultViewURL">
+<xsl:with-param name="BiblioDefaultView">
+<xsl:value-of select="$BiblioDefaultView"/>
+</xsl:with-param>
+</xsl:call-template>
+<xsl:value-of select="$biblionumber"/>
+</xsl:attribute>
+<xsl:attribute name="class">title</xsl:attribute>
+<xsl:value-of select="$ntitle" />
+</a>
+</xsl:when>
+<xsl:when test="@code='b'">
+<xsl:text> [</xsl:text>
+<xsl:value-of select="."/>
+<xsl:text>]</xsl:text>
+</xsl:when>
+<xsl:when test="@code='d'">
+<xsl:text> = </xsl:text>
+<xsl:value-of select="."/>
+</xsl:when>
+<xsl:when test="@code='e'">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="."/>
+</xsl:when>
+<xsl:when test="@code='f'">
+<xsl:text> / </xsl:text>
+<xsl:value-of select="."/>
+</xsl:when>
+<xsl:when test="@code='g'">
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="."/>
+</xsl:when>
+<xsl:otherwise>
+<xsl:text>, </xsl:text>
+<xsl:value-of select="."/>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:for-each>
+</xsl:for-each>
+</xsl:if>
+
+
+<xsl:if test="marc:datafield[@tag=099]/marc:subfield[@code='t']">
+  <span class="results_summary">
+    <span class="label">Catégorie de document : </span>
+    <xsl:for-each select="marc:datafield[@tag=099]/marc:subfield[@code='t']">
+      <xsl:value-of select="."/>
+      <xsl:if test="not(position()=last())"><xsl:text> ; </xsl:text></xsl:if>
+    </xsl:for-each>
+  </span>
+</xsl:if>
+
+<!--Titre de serie - autorité 461-->
+<!--<xsl:call-template name="tag_461" />-->
+
+<!--Titre de serie non autorité 461-->
+<xsl:call-template name="tag_461bis" />
+
+<!--Titre dépouillé 463-->
+<xsl:call-template name="tag_463" />
+
+<xsl:if test="contains($type_doc,'Revue')">
+<xsl:call-template name="tag_462" />
+</xsl:if>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">412</xsl:with-param>
+<xsl:with-param name="label">Est un extrait ou tiré à part de</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">413</xsl:with-param>
+<xsl:with-param name="label">A pour extrait ou tiré à part</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">421</xsl:with-param>
+<xsl:with-param name="label">A pour supplément</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">422</xsl:with-param>
+<xsl:with-param name="label">Est un supplément de</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">423</xsl:with-param>
+<xsl:with-param name="label">Est publié avec</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">424</xsl:with-param>
+<xsl:with-param name="label">Est mis à jour par</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">430</xsl:with-param>
+<xsl:with-param name="label">Suite de</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">431</xsl:with-param>
+<xsl:with-param name="label">Succède après scission à</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">432</xsl:with-param>
+<xsl:with-param name="label">Remplace</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">433</xsl:with-param>
+<xsl:with-param name="label">Remplace partiellement</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">434</xsl:with-param>
+<xsl:with-param name="label">Absorbe</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">435</xsl:with-param>
+<xsl:with-param name="label">Absorbe partiellement</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">436</xsl:with-param>
+<xsl:with-param name="label">Fusion de</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">437</xsl:with-param>
+<xsl:with-param name="label">Suite partielle de</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">440</xsl:with-param>
+<xsl:with-param name="label">Devient</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">441</xsl:with-param>
+<xsl:with-param name="label">Devient partiellement</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">442</xsl:with-param>
+<xsl:with-param name="label">Remplacé par</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">443</xsl:with-param>
+<xsl:with-param name="label">Remplacé partiellement par</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">444</xsl:with-param>
+<xsl:with-param name="label">Absorbé par</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">447</xsl:with-param>
+<xsl:with-param name="label">Fusionné avec...pour former</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">451</xsl:with-param>
+<xsl:with-param name="label">A pour autre édition, sur le même support</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">452</xsl:with-param>
+<xsl:with-param name="label">A pour autre édition, sur un support différent</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">453</xsl:with-param>
+<xsl:with-param name="label">Traduit sous le titre</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">454</xsl:with-param>
+<xsl:with-param name="label">Est une traduction de</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">455</xsl:with-param>
+<xsl:with-param name="label">Est une reproduction de</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">456</xsl:with-param>
+<xsl:with-param name="label">Est reproduit comme</xsl:with-param>
+</xsl:call-template>
+
+<!--<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">464</xsl:with-param>
+<xsl:with-param name="label">Composante</xsl:with-param>
+</xsl:call-template>-->
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">470</xsl:with-param>
+<xsl:with-param name="label">Document analysé</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">481</xsl:with-param>
+<xsl:with-param name="label">Est aussi lié dans ce volume</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">482</xsl:with-param>
+<xsl:with-param name="label">Relié à la suite de</xsl:with-param>
+</xsl:call-template>
+
+<xsl:call-template name="tag_4xx">
+<xsl:with-param name="tag">488</xsl:with-param>
+<xsl:with-param name="label">Autre type de relation</xsl:with-param>
+</xsl:call-template>
+
+<xsl:if test="(marc:datafield[@tag=214] or marc:datafield[@tag=210])">
+<xsl:choose>
+<xsl:when test="(marc:datafield[@tag=214]/marc:subfield[@code='r'])">
+<xsl:call-template name="tag_214_r" />
+</xsl:when>
+<xsl:when test="(marc:datafield[@tag=214]/marc:subfield[@code='s'])">
+<xsl:call-template name="tag_214_s" />
+</xsl:when>
+<xsl:when test="(marc:datafield[@tag=210]/marc:subfield[@code='r'])">
+<xsl:call-template name="tag_210_r" />
+</xsl:when>
+<xsl:when test="(marc:datafield[@tag=210]/marc:subfield[@code='s'])">
+<xsl:call-template name="tag_210_s" />
+</xsl:when>
+<xsl:when test="(marc:datafield[@tag=214] and  marc:datafield[@tag=210])">
+<xsl:call-template name="tag_214" />
+</xsl:when>
+<xsl:when test="(marc:datafield[@tag=214])">
+<xsl:call-template name="tag_214" />
+</xsl:when>
+<xsl:when test="(marc:datafield[@tag=210])">
+<xsl:call-template name="tag_210" />
+</xsl:when>
+</xsl:choose>
+</xsl:if>
+
+
+
+<xsl:call-template name="tag_215" />
+
+<!--Collection autorité-->
+<!--
+<xsl:for-each select="marc:datafield[@tag=410]">
+<span class="results_summary">
+<span class="label">
+Collection-Autorité : </span>
+<xsl:element name="a"><xsl:attribute name="href">
+/cgi-bin/koha/catalogue/search.pl?q=an:<xsl:value-of select="marc:subfield[@code='9']"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:element>
+<xsl:if test="marc:subfield[@code='t'] and marc:subfield[@code='v']">
+<xsl:text> . </xsl:text>
+<xsl:value-of select="marc:subfield[@code='v']"/>
+</xsl:if>
+</span>
+</xsl:for-each>-->
+
+<!--Etat de collection-->
+<xsl:if test="marc:datafield[@tag=923]">
+    <span class="results_summary">
+<span class="label">État des collections : </span>
+          <xsl:for-each select="marc:datafield[@tag=923]">
+ <xsl:if test="marc:subfield[@code='r']">
+            <dd>
+              <xsl:if test="marc:subfield[@code='b']">
+                        <xsl:call-template name="RCR">
+                              <xsl:with-param name="code" select="marc:subfield[@code='b']"/>
+                        </xsl:call-template>
+                  </xsl:if>
+                      <xsl:if test="marc:subfield[@code='r']">
+                  <xsl:text> </xsl:text>
+                  <span class="statutdispo">
+                                <xsl:value-of select="marc:subfield[@code='r']"/>
+                  </span>
+                      </xsl:if>
+                <xsl:if test="marc:subfield[@code='a']">
+                  <xsl:text> (Cote : </xsl:text>
+                  <xsl:value-of select="marc:subfield[@code='a']" />
+                  <xsl:text>)</xsl:text>
+                </xsl:if>
+              </dd>
+ </xsl:if>
+          </xsl:for-each>
+</span>
+</xsl:if>
+
+
+<xsl:if test="marc:datafield[@tag=856]/marc:subfield[@code='u']"> 
+<span class="results_summary"> 
+<span class="label">Ressource en ligne : </span> 
+<xsl:for-each select="marc:datafield[@tag=856]"> 
+<xsl:variable name="url" select="substring-before(marc:subfield[@code='u'], '//')"/> 
+<xsl:if test="contains($url,'https:') or contains($url,'http:')"> 
+<a> 
+<xsl:attribute name="href"> 
+<xsl:value-of select="marc:subfield[@code='u']"/> 
+</xsl:attribute> 
+<xsl:choose> 
+<xsl:when test="marc:subfield[@code='y' or @code='3' or @code='z']"> 
+<xsl:call-template name="subfieldSelect"> 
+<xsl:with-param name="codes">y3z</xsl:with-param> 
+</xsl:call-template> 
+</xsl:when> 
+<xsl:when test="not(marc:subfield[@code='y']) and not(marc:subfield[@code='3']) and not(marc:subfield[@code='z'])"> 
+Cliquer ici 
+</xsl:when> 
+</xsl:choose> 
+</a> 
+</xsl:if> 
+<xsl:if test="not(contains($url,'http:')) and not(contains($url,'https:'))"> 
+<a> 
+<xsl:attribute name="href"> 
+<xsl:value-of select="marc:subfield[@code='u']"/> 
+</xsl:attribute> 
+<xsl:choose> 
+<xsl:when test="marc:subfield[@code='y' or @code='3' or @code='z']"> 
+<xsl:call-template name="subfieldSelect"> 
+<xsl:with-param name="codes">y3z</xsl:with-param> 
+</xsl:call-template> 
+</xsl:when> 
+<xsl:when test="not(marc:subfield[@code='y']) and not(marc:subfield[@code='3']) and not(marc:subfield[@code='z'])"> 
+Cliquer ici 
+</xsl:when> 
+</xsl:choose> 
+</a> 
+</xsl:if> 
+<xsl:choose> 
+<xsl:when test="position()=last()"/> 
+<xsl:otherwise> | </xsl:otherwise> 
+</xsl:choose> 
+</xsl:for-each> 
+</span> 
+</xsl:if>
+
+
+<!--Public  995q-->
+<!--<xsl:call-template name="public" />-->
+
+<!--Fonds 995h-->
+<!--<xsl:call-template name="fonds" />-->
+
+
+<xsl:if test="marc:datafield[@tag=995]">
+<span class="results_summary availability">
+<span class="label">Disponibilité : </span>
+<xsl:choose>
+<xsl:when test="marc:datafield[@tag=1856]">
+<xsl:for-each select="marc:datafield[@tag=1856]">
+<xsl:choose>
+<xsl:when test="@ind2=0">
+<a>
+<xsl:attribute name="href">
+<xsl:value-of select="marc:subfield[@code='u']"/>
+</xsl:attribute>
+<xsl:if test="$OPACURLOpenInNewWindow='1'">
+<xsl:attribute name="target">_blank</xsl:attribute>
+</xsl:if>
+<xsl:choose>
+<xsl:when test="marc:subfield[@code='y' or code='3' or  @code='z']">
+<xsl:call-template name="subfieldSelect">
+<xsl:with-param name="codes">y3z</xsl:with-param>
+</xsl:call-template>
+</xsl:when>
+<xsl:when test="not(marc:subfield[@code='y']) and not(marc:subfield[@code='3']) and not(marc:subfield[@code='z'])">
+Cliquez ici pour consulter en ligne </xsl:when>
+</xsl:choose>
+</a>
+<xsl:choose>
+<xsl:when test="position()=last()"></xsl:when>
+<xsl:otherwise> | </xsl:otherwise>
+</xsl:choose>
+</xsl:when>
+</xsl:choose>
+</xsl:for-each>
+</xsl:when>
+<xsl:when test="count(key('item-by-status', 'available'))=0 and count(key('item-by-status', 'reference'))=0">
+Aucun exemplaire disponible </xsl:when>
+<xsl:when test="count(key('item-by-status', 'available'))>0">
+<span class="available">
+<b><xsl:text>Exemplaire(s) disponible(s) : </xsl:text></b>
+<xsl:variable name="available_items" select="key('item-by-status', 'available')"/>
+<xsl:choose>
+<xsl:when test="$singleBranchMode=1">
+<xsl:for-each select="$available_items[generate-id() = generate-id(key('item-by-status-and-branch-home', concat(items:status, ' ', items:homebranch))[1])]">
+<xsl:if test="items:itemcallnumber != '' and items:itemcallnumber"> [<xsl:value-of select="items:itemcallnumber"/>]</xsl:if>
+<xsl:text> (</xsl:text>
+<xsl:value-of select="count(key('item-by-status-and-branch-home', concat(items:status, ' ', items:homebranch)))"/>
+<xsl:text>)</xsl:text>
+<xsl:choose><xsl:when test="position()=last()"><xsl:text>. </xsl:text></xsl:when><xsl:otherwise><xsl:text>, </xsl:text></xsl:otherwise></xsl:choose>
+</xsl:for-each>
+</xsl:when>
+<xsl:otherwise>
+<xsl:choose>
+<xsl:when test="$OPACResultsLibrary='homebranch'">
+<xsl:for-each select="$available_items[generate-id() = generate-id(key('item-by-status-and-branch-home', concat(items:status, ' ', items:homebranch))[1])]">
+<xsl:value-of select="items:homebranch"/>
+<xsl:if test="items:itemcallnumber != '' and items:itemcallnumber">[<xsl:value-of select="items:itemcallnumber"/>]
+</xsl:if>
+<xsl:text> (</xsl:text>
+<xsl:value-of select="count(key('item-by-status-and-branch-home', concat(items:status, ' ', items:homebranch)))"/>
+<xsl:text>)</xsl:text>
+<xsl:choose>
+<xsl:when test="position()=last()">
+<xsl:text>. </xsl:text>
+</xsl:when>
+<xsl:otherwise>
+<xsl:text>, </xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:for-each>
+</xsl:when>
+<xsl:otherwise>
+<xsl:for-each select="$available_items[generate-id() = generate-id(key('item-by-status-and-branch-holding', concat(items:status, ' ', items:holdingbranch))[1])]">
+<xsl:value-of select="items:holdingbranch"/>
+<xsl:if test="items:itemcallnumber != '' and items:itemcallnumber">[<xsl:value-of select="items:itemcallnumber"/>]
+</xsl:if>
+<xsl:text> (</xsl:text>
+<xsl:value-of select="count(key('item-by-status-and-branch-holding', concat(items:status, ' ', items:holdingbranch)))"/>
+<xsl:text>)</xsl:text>
+<xsl:choose>
+<xsl:when test="position()=last()">
+<xsl:text>. </xsl:text>
+</xsl:when>
+<xsl:otherwise>
+<xsl:text>, </xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:for-each>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:otherwise>
+</xsl:choose>
+</span>
+</xsl:when>
+</xsl:choose>
+<xsl:choose>
+<xsl:when test="count(key('item-by-status', 'reference'))>0">
+<span class="unavailable">
+<b><xsl:text>Exemplaires exclu du prêt : </xsl:text></b>
+<xsl:variable name="reference_items"
+select="key('item-by-status', 'reference')"/>
+<xsl:for-each select="$reference_items[generate-id() = generate-id(key('item-by-status-and-branch-home', concat(items:status, ' ', items:homebranch))[1])]">
+<xsl:if test="$singleBranchMode=0">
+<xsl:value-of select="items:homebranch"/>
+</xsl:if>
+<xsl:if test="items:itemcallnumber != '' and items:itemcallnumber">[<xsl:value-of select="items:itemcallnumber"/>]</xsl:if>
+<xsl:text> (</xsl:text>
+<xsl:value-of select="count(key('item-by-status-and-branch-home', concat(items:status, ' ', items:homebranch)))"/>
+<xsl:text>)</xsl:text>
+<xsl:choose>
+<xsl:when test="position()=last()">
+<xsl:text>. </xsl:text>
+</xsl:when>
+<xsl:otherwise>
+<xsl:text>, </xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:for-each>
+</span>
+</xsl:when>
+</xsl:choose>
+<xsl:if test="count(key('item-by-status', 'Checked out'))>0">
+<span class="unavailable">
+<xsl:text> En prêt (</xsl:text>
+<xsl:value-of select="count(key('item-by-status', 'Checked out'))"/>
+<xsl:text>). </xsl:text>
+</span>
+</xsl:if>
+<xsl:if test="count(key('item-by-status', 'Withdrawn'))>0">
+<span class="unavailable">
+<xsl:text> Retiré des collections (</xsl:text>
+<xsl:value-of select="count(key('item-by-status', 'Withdrawn'))"/>
+<xsl:text>). </xsl:text>
+</span>
+</xsl:if>
+<xsl:if test="$hidelostitems='0' and count(key('item-by-status', 'Lost'))>0">
+<span class="unavailable">
+<xsl:text> Perdu (</xsl:text>
+<xsl:value-of select="count(key('item-by-status', 'Lost'))"/>
+<xsl:text>). </xsl:text>
+</span>
+</xsl:if>
+<xsl:if test="count(key('item-by-status', 'Damaged'))>0">
+<span class="unavailable">
+<xsl:text> Endommagé (</xsl:text>
+<xsl:value-of select="count(key('item-by-status', 'Damaged'))"/>
+<xsl:text>). </xsl:text>
+</span>
+</xsl:if>
+<xsl:if test="count(key('item-by-status', 'On order'))>0">
+<span class="unavailable">
+<xsl:text> En commande (</xsl:text>
+<xsl:value-of select="count(key('item-by-status', 'On order'))"/>
+<xsl:text>). </xsl:text>
+</span>
+</xsl:if>
+<xsl:if test="count(key('item-by-status', 'In transit'))>0">
+<span class="unavailable">
+<xsl:text> En transit (</xsl:text>
+<xsl:value-of select="count(key('item-by-status', 'In transit'))"/>
+<xsl:text>). </xsl:text>
+</span>
+</xsl:if>
+<xsl:if test="count(key('item-by-status', 'Waiting'))>0">
+<span class="unavailable">
+<xsl:text> Réservé (</xsl:text>
+<xsl:value-of select="count(key('item-by-status', 'Waiting'))"/>
+<xsl:text>). </xsl:text>
+</span>
+</xsl:if>
+</span>
+</xsl:if>
+</xsl:template>
+
+</xsl:stylesheet>

--- a/biblibre/opac/fr-FR/UNIMARCslimUtils.xsl
+++ b/biblibre/opac/fr-FR/UNIMARCslimUtils.xsl
@@ -1,0 +1,1563 @@
+<xsl:stylesheet version="1.0"
+  xmlns:marc="http://www.loc.gov/MARC21/slim"
+  xmlns:items="http://www.koha-community.org/items"
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  exclude-result-prefixes="marc items">
+
+ <xsl:template name="datafield">
+ <xsl:param name="tag"/>
+ <xsl:param name="ind1"><xsl:text> </xsl:text></xsl:param>
+ <xsl:param name="ind2"><xsl:text> </xsl:text></xsl:param>
+ <xsl:param name="subfields"/>
+ <xsl:element name="datafield">
+ <xsl:attribute name="tag">
+ <xsl:value-of select="$tag"/>
+ </xsl:attribute>
+ <xsl:attribute name="ind1">
+ <xsl:value-of select="$ind1"/>
+ </xsl:attribute>
+ <xsl:attribute name="ind2">
+ <xsl:value-of select="$ind2"/>
+ </xsl:attribute>
+ <xsl:copy-of select="$subfields"/>
+ </xsl:element>
+ </xsl:template>
+
+ <xsl:template name="subfieldSelect">
+ <xsl:param name="codes"/>
+ <xsl:param name="delimeter"><xsl:text> </xsl:text></xsl:param>
+ <xsl:param name="subdivCodes"/>
+ <xsl:param name="subdivDelimiter"/>
+ <xsl:variable name="str">
+ <xsl:for-each select="marc:subfield">
+ <xsl:if test="contains($codes, @code)">
+ <xsl:if test="contains($subdivCodes, @code)">
+ <xsl:value-of select="$subdivDelimiter"/>
+ </xsl:if>
+ <xsl:value-of select="text()"/><xsl:value-of select="$delimeter"/>
+ </xsl:if>
+ </xsl:for-each>
+ </xsl:variable>
+ <xsl:value-of select="substring($str,1,string-length($str)-string-length($delimeter))"/>
+ </xsl:template>
+
+ <xsl:template name="buildSpaces">
+ <xsl:param name="spaces"/>
+ <xsl:param name="char"><xsl:text> </xsl:text></xsl:param>
+ <xsl:if test="$spaces>0">
+ <xsl:value-of select="$char"/>
+ <xsl:call-template name="buildSpaces">
+ <xsl:with-param name="spaces" select="$spaces - 1"/>
+ <xsl:with-param name="char" select="$char"/>
+ </xsl:call-template>
+ </xsl:if>
+ </xsl:template>
+
+ <xsl:template name="buildBiblioDefaultViewURL">
+ <xsl:param name="BiblioDefaultView"/>
+ <xsl:choose>
+ <xsl:when test="$BiblioDefaultView='normal'">
+ <xsl:text>/cgi-bin/koha/opac-detail.pl?biblionumber=</xsl:text>
+ </xsl:when>
+ <xsl:when test="$BiblioDefaultView='isbd'">
+ <xsl:text>/cgi-bin/koha/opac-ISBDdetail.pl?biblionumber=</xsl:text>
+ </xsl:when>
+ <xsl:when test="$BiblioDefaultView='marc'">
+ <xsl:text>/cgi-bin/koha/opac-MARCdetail.pl?biblionumber=</xsl:text>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text>/cgi-bin/koha/opac-detail.pl?biblionumber=</xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:template>
+
+
+ <xsl:template name="chopPunctuation">
+ <xsl:param name="chopString"/>
+ <xsl:variable name="length" select="string-length($chopString)"/>
+ <xsl:choose>
+ <xsl:when test="$length=0"/>
+ <xsl:when test="contains('.:,;/ ', substring($chopString,$length,1))">
+ <xsl:call-template name="chopPunctuation">
+ <xsl:with-param name="chopString" select="substring($chopString,1,$length - 1)"/>
+ </xsl:call-template>
+ </xsl:when>
+ <xsl:when test="not($chopString)"/>
+ <xsl:otherwise><xsl:value-of select="$chopString"/></xsl:otherwise>
+ </xsl:choose>
+ <xsl:text> </xsl:text>
+ </xsl:template>
+
+ <xsl:template name="addClassRtl">
+ <xsl:variable name="lang" select="marc:subfield[@code='7']" />
+ <xsl:if test="$lang = 'ha' or $lang = 'Hebrew' or $lang = 'fa' or $lang = 'Arabe'">
+ <xsl:attribute name="class">rtl</xsl:attribute>
+ </xsl:if>
+ </xsl:template>
+
+ <xsl:template name="tag_title">
+ <xsl:param name="tag" />
+ <xsl:param name="label" />
+ <xsl:param name="spanclass" />
+ <xsl:if test="marc:datafield[@tag=$tag]">
+ <span class="results_summary">
+ <span class="label">
+ <xsl:value-of select="$label"/>: </span>
+ <xsl:for-each select="marc:datafield[@tag=$tag]">
+ <xsl:call-template name="addClassRtl" />
+ <xsl:for-each select="marc:subfield">
+ <xsl:choose>
+ <xsl:when test="@code='a'">
+ <xsl:variable name="title" select="."/>
+ <xsl:variable name="ntitle"
+ select="translate($title, '&#x0088;&#x0089;&#x0098;&#x009C;','')"/>
+ <xsl:value-of select="$ntitle" />
+ </xsl:when>
+ <xsl:when test="@code='b'">
+ <xsl:text>[</xsl:text>
+ <xsl:value-of select="."/>
+ <xsl:text>]</xsl:text>
+ </xsl:when>
+ <xsl:when test="@code='d'">
+ <xsl:text> = </xsl:text>
+ <xsl:value-of select="."/>
+ </xsl:when>
+ <xsl:when test="@code='e'">
+ <xsl:text> : </xsl:text>
+ <xsl:value-of select="."/>
+ </xsl:when>
+ <xsl:when test="@code='f'">
+ <xsl:text> / </xsl:text>
+ <xsl:value-of select="."/>
+ </xsl:when>
+ <xsl:when test="@code='g'">
+ <xsl:text> ; </xsl:text>
+ <xsl:value-of select="."/>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:if test="position()>1">
+ <xsl:text>, </xsl:text>
+ </xsl:if>
+ <xsl:value-of select="."/>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:for-each>
+ <xsl:if test="not (position() = last())">
+ <xsl:text> • </xsl:text>
+ </xsl:if>
+ </xsl:for-each>
+ </span>
+ </xsl:if>
+ </xsl:template>
+
+ <xsl:template name="tag_comma">
+ <xsl:param name="tag" />
+ <xsl:param name="label" />
+ <xsl:param name="spanclass" />
+ <xsl:if test="marc:datafield[@tag=$tag]">
+ <span class="results_summary {$spanclass}">
+ <span class="label">
+ <xsl:value-of select="$label"/>: </span>
+ <xsl:for-each select="marc:datafield[@tag=$tag]">
+ <xsl:call-template name="addClassRtl" />
+ <xsl:for-each select="marc:subfield">
+ <xsl:if test="position()>1">
+ <xsl:text>, </xsl:text>
+ </xsl:if>
+ <xsl:value-of select="."/>
+ </xsl:for-each>
+ <xsl:if test="not (position() = last())">
+ <xsl:text> • </xsl:text>
+ </xsl:if>
+ </xsl:for-each>
+ </span>
+ </xsl:if>
+ </xsl:template>
+
+ <xsl:template name="tag_210">
+<xsl:for-each select="marc:datafield[@tag=210]">
+<span class="results_summary">
+<span class="label">Publication : </span>
+<xsl:choose>
+<xsl:when test="(marc:subfield[@code='a'][2]) and (marc:subfield[@code='c'][2]) and (marc:subfield[@code='d'])">
+<xsl:value-of select="marc:subfield[@code='a'][1]"/>
+<xsl:text> : </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Publisher&amp;q=
+<xsl:value-of select="marc:subfield[@code='c'][1]"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c'][1]"/>
+</xsl:element>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='a'][2]"/>
+<xsl:text> : </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Publisher&amp;q=
+<xsl:value-of select="marc:subfield[@code='c'][2]"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c'][2]"/>
+</xsl:element>
+<xsl:if test="marc:subfield[@code='a'][3]">
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='a'][3]"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='c'][3]">
+<xsl:text> : </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Publisher&amp;q=
+<xsl:value-of select="marc:subfield[@code='c'][3]"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c'][3]"/>
+</xsl:element>
+</xsl:if>
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='c'][2]) and (marc:subfield[@code='d'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:if test="position()!=last()">
+<xsl:text> ; </xsl:text>
+</xsl:if>
+<xsl:if test="position()=last()">
+<xsl:text> : </xsl:text>
+</xsl:if>
+<xsl:for-each select="marc:subfield[@code='c']">
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Publisher&amp;q=
+<xsl:value-of select="text()"/>
+</xsl:attribute>
+<xsl:value-of select="text()"/>
+</xsl:element>
+<xsl:if test="position()!=last()">
+<xsl:text> : </xsl:text>
+</xsl:if>
+<xsl:if test="position()=last()">
+<xsl:text></xsl:text>
+</xsl:if>
+</xsl:for-each>
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a'][2]) and (marc:subfield[@code='c']) and (marc:subfield[@code='d'])">
+<xsl:for-each select="marc:subfield[@code='a']">
+<xsl:value-of select="text()"/>
+<xsl:if test="position()!=last()">
+<xsl:text> ; </xsl:text>
+</xsl:if>
+<xsl:if test="position()=last()">
+<xsl:text> : </xsl:text>
+</xsl:if>
+</xsl:for-each>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Publisher&amp;q=
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:element>
+<xsl:if test="position()!=last()">
+<xsl:text> : </xsl:text>
+</xsl:if>
+<xsl:if test="position()=last()">
+<xsl:text></xsl:text>
+</xsl:if>
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='c']) and (marc:subfield[@code='d'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text> : </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Publisher&amp;q=
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:element>
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='c'][2])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text> : </xsl:text>
+<xsl:for-each select="marc:subfield[@code='c']">
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Publisher&amp;q=
+<xsl:value-of select="text()"/>
+</xsl:attribute>
+<xsl:value-of select="text()"/>
+</xsl:element>
+<xsl:if test="position()!=last()">
+<xsl:text> : </xsl:text>
+</xsl:if>
+<xsl:if test="position()=last()">
+<xsl:text></xsl:text>
+</xsl:if>
+</xsl:for-each>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='c'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text> : </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Publisher&amp;q=
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:element>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='c'][2]) and (marc:subfield[@code='d'])">
+<xsl:for-each select="marc:subfield[@code='c']">
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Publisher&amp;q=
+<xsl:value-of select="text()"/>
+</xsl:attribute>
+<xsl:value-of select="text()"/>
+</xsl:element>
+<xsl:if test="position()!=last()">
+<xsl:text> : </xsl:text>
+</xsl:if>
+<xsl:if test="position()=last()">
+<xsl:text>, </xsl:text>
+</xsl:if>
+</xsl:for-each>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='c']) and (marc:subfield[@code='d'])">
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Publisher&amp;q=
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:element>
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a'][2]) and (marc:subfield[@code='d'])">
+<xsl:for-each select="marc:subfield[@code='a']">
+<xsl:value-of select="text()"/>
+<xsl:if test="position()!=last()">
+<xsl:text> ; </xsl:text>
+</xsl:if>
+<xsl:if test="position()=last()">
+<xsl:text>, </xsl:text>
+</xsl:if>
+</xsl:for-each>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='d'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+
+<xsl:when test="(marc:subfield[@code='c'])">
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Publisher&amp;q=
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:element>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='d'])">
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='e'])">
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='h']">
+<xsl:text> , </xsl:text>
+<xsl:value-of select="marc:subfield[@code='h']"/>
+</xsl:if>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='g'])">
+<xsl:value-of select="marc:subfield[@code='g']"/>
+<xsl:if test="marc:subfield[@code='h']">
+<xsl:text> , </xsl:text>
+<xsl:value-of select="marc:subfield[@code='h']"/>
+</xsl:if>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='h'])">
+<xsl:value-of select="marc:subfield[@code='h']"/>
+</xsl:when>
+
+
+
+</xsl:choose>
+</span>
+</xsl:for-each>
+ </xsl:template>
+
+
+ <xsl:template name="tag_214">
+<xsl:for-each select="marc:datafield[@tag=214]">
+<span class="results_summary">
+<span class="label">Publication : </span>
+<xsl:choose>
+<xsl:when test="(marc:subfield[@code='a'][2]) and (marc:subfield[@code='c'][2]) and (marc:subfield[@code='d'])">
+<xsl:value-of select="marc:subfield[@code='a'][1]"/>
+<xsl:text> : </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Publisher&amp;q=
+<xsl:value-of select="marc:subfield[@code='c'][1]"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c'][1]"/>
+</xsl:element>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='a'][2]"/>
+<xsl:text> : </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Publisher&amp;q=
+<xsl:value-of select="marc:subfield[@code='c'][2]"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c'][2]"/>
+</xsl:element>
+<xsl:if test="marc:subfield[@code='a'][3]">
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='a'][3]"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='c'][3]">
+<xsl:text> : </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Publisher&amp;q=
+<xsl:value-of select="marc:subfield[@code='c'][3]"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c'][3]"/>
+</xsl:element>
+</xsl:if>
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='c'][2]) and (marc:subfield[@code='d'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:if test="position()!=last()">
+<xsl:text> ; </xsl:text>
+</xsl:if>
+<xsl:if test="position()=last()">
+<xsl:text> : </xsl:text>
+</xsl:if>
+<xsl:for-each select="marc:subfield[@code='c']">
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Publisher&amp;q=
+<xsl:value-of select="text()"/>
+</xsl:attribute>
+<xsl:value-of select="text()"/>
+</xsl:element>
+<xsl:if test="position()!=last()">
+<xsl:text> : </xsl:text>
+</xsl:if>
+<xsl:if test="position()=last()">
+<xsl:text></xsl:text>
+</xsl:if>
+</xsl:for-each>
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a'][2]) and (marc:subfield[@code='c']) and (marc:subfield[@code='d'])">
+<xsl:for-each select="marc:subfield[@code='a']">
+<xsl:value-of select="text()"/>
+<xsl:if test="position()!=last()">
+<xsl:text> ; </xsl:text>
+</xsl:if>
+<xsl:if test="position()=last()">
+<xsl:text> : </xsl:text>
+</xsl:if>
+</xsl:for-each>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Publisher&amp;q=
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:element>
+<xsl:if test="position()!=last()">
+<xsl:text> : </xsl:text>
+</xsl:if>
+<xsl:if test="position()=last()">
+<xsl:text></xsl:text>
+</xsl:if>
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='c']) and (marc:subfield[@code='d'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text> : </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Publisher&amp;q=
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:element>
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='c'][2])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text> : </xsl:text>
+<xsl:for-each select="marc:subfield[@code='c']">
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Publisher&amp;q=
+<xsl:value-of select="text()"/>
+</xsl:attribute>
+<xsl:value-of select="text()"/>
+</xsl:element>
+<xsl:if test="position()!=last()">
+<xsl:text> : </xsl:text>
+</xsl:if>
+<xsl:if test="position()=last()">
+<xsl:text></xsl:text>
+</xsl:if>
+</xsl:for-each>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='c'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text> : </xsl:text>
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Publisher&amp;q=
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:element>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='c'][2]) and (marc:subfield[@code='d'])">
+<xsl:for-each select="marc:subfield[@code='c']">
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Publisher&amp;q=
+<xsl:value-of select="text()"/>
+</xsl:attribute>
+<xsl:value-of select="text()"/>
+</xsl:element>
+<xsl:if test="position()!=last()">
+<xsl:text> : </xsl:text>
+</xsl:if>
+<xsl:if test="position()=last()">
+<xsl:text>, </xsl:text>
+</xsl:if>
+</xsl:for-each>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='c']) and (marc:subfield[@code='d'])">
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Publisher&amp;q=
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:element>
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a'][2]) and (marc:subfield[@code='d'])">
+<xsl:for-each select="marc:subfield[@code='a']">
+<xsl:value-of select="text()"/>
+<xsl:if test="position()!=last()">
+<xsl:text> ; </xsl:text>
+</xsl:if>
+<xsl:if test="position()=last()">
+<xsl:text>, </xsl:text>
+</xsl:if>
+</xsl:for-each>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='d'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text>, </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='a'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='c'])">
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Publisher&amp;q=
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:attribute>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:element>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='d'])">
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:if test="marc:subfield[@code='e']">
+<xsl:text> (</xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:text>)</xsl:text>
+</xsl:if>
+</xsl:when>
+
+<xsl:when test="(marc:subfield[@code='e'])">
+<xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:if test="marc:subfield[@code='g']">
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='g']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='h']">
+<xsl:text> , </xsl:text>
+<xsl:value-of select="marc:subfield[@code='h']"/>
+</xsl:if>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='g'])">
+<xsl:value-of select="marc:subfield[@code='g']"/>
+<xsl:if test="marc:subfield[@code='h']">
+<xsl:text> , </xsl:text>
+<xsl:value-of select="marc:subfield[@code='h']"/>
+</xsl:if>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='h'])">
+<xsl:value-of select="marc:subfield[@code='h']"/>
+</xsl:when>
+</xsl:choose>
+</span>
+</xsl:for-each>
+ </xsl:template>
+
+<!--210$s et $r Colophon et adresse transcrite-->
+<xsl:template name="tag_210_s">
+<xsl:if test="marc:datafield[@tag=210]/marc:subfield[@code='s']">
+<span class="results_summary">
+<span class="label">Colophon : </span>
+<xsl:for-each select="marc:datafield[@tag=210]">
+<xsl:value-of select="marc:subfield[@code='s']"/>
+<xsl:choose>
+<xsl:when test="position()=last()">
+<xsl:text>.</xsl:text>
+</xsl:when>
+<xsl:otherwise><xsl:text>, </xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:for-each>
+</span>
+</xsl:if>
+</xsl:template>
+
+<xsl:template name="tag_210_r">
+<xsl:if test="marc:datafield[@tag=210]/marc:subfield[@code='r']">
+<span class="results_summary">
+<span class="label">Adresse transcrite : </span>
+<xsl:for-each select="marc:datafield[@tag=210]">
+<xsl:value-of select="marc:subfield[@code='r']"/>
+<xsl:choose>
+<xsl:when test="position()=last()">
+<xsl:text>.</xsl:text>
+</xsl:when>
+<xsl:otherwise><xsl:text>, </xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:for-each>
+</span>
+</xsl:if>
+</xsl:template>
+
+<!--TB-214$s et $r Colophon et adresse transcrite-->
+<xsl:template name="tag_214_s">
+<xsl:if test="marc:datafield[@tag=214]/marc:subfield[@code='s']">
+<span class="results_summary">
+<span class="label">Colophon : </span>
+<xsl:for-each select="marc:datafield[@tag=214]">
+<xsl:value-of select="marc:subfield[@code='s']"/>
+<xsl:choose>
+<xsl:when test="position()=last()">
+<xsl:text>.</xsl:text>
+</xsl:when>
+<xsl:otherwise><xsl:text>, </xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:for-each>
+</span>
+</xsl:if>
+</xsl:template>
+
+<xsl:template name="tag_214_r">
+<xsl:if test="marc:datafield[@tag=214]/marc:subfield[@code='r']">
+<span class="results_summary">
+<span class="label">Adresse transcrite : </span>
+<xsl:for-each select="marc:datafield[@tag=210]">
+<xsl:value-of select="marc:subfield[@code='r']"/>
+<xsl:choose>
+<xsl:when test="position()=last()">
+<xsl:text>.</xsl:text>
+</xsl:when>
+<xsl:otherwise><xsl:text>, </xsl:text>
+</xsl:otherwise>
+</xsl:choose>
+</xsl:for-each>
+</span>
+</xsl:if>
+</xsl:template>
+
+
+
+
+
+
+ <xsl:template name="tag_215">
+ <xsl:for-each select="marc:datafield[@tag=215]">
+ <span class="results_summary">
+ <span class="label">Description : </span>
+<xsl:choose>
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='c']) and (marc:subfield[@code='d']) and (marc:subfield[@code='e'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:text> + </xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='c']) and (marc:subfield[@code='d'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='e']) and (marc:subfield[@code='d'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:text> + </xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='e']) and (marc:subfield[@code='c'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+<xsl:text> + </xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='c'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text> : </xsl:text>
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='d'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='d']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='a']) and (marc:subfield[@code='e'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+<xsl:text> + </xsl:text>
+<xsl:value-of select="marc:subfield[@code='e']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='a'])">
+<xsl:value-of select="marc:subfield[@code='a']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='c'])">
+<xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='d'])">
+<xsl:value-of select="marc:subfield[@code='d']"/>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='e'])">
+<xsl:value-of select="marc:subfield[@code='e']"/>
+</xsl:when>
+</xsl:choose>
+ </span>
+ </xsl:for-each>
+ </xsl:template>
+
+<!--Titre de serie - autorité 461-->
+<xsl:template name="tag_461">
+<xsl:for-each select="marc:datafield[@tag=461]">
+<span class="results_summary">
+<span class="label">Titre de série  : </span>
+<xsl:call-template name="addClassRtl" />
+<xsl:choose>
+<xsl:when test="marc:subfield[@code='9']">
+<xsl:element name="a"><xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?q=an:<xsl:value-of select="marc:subfield[@code='9']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='t']"/></xsl:element>
+</xsl:when>
+<xsl:otherwise>
+<xsl:element name="a"><xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=index-title-serie,phr&amp;q=<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='t']"/></xsl:element>
+</xsl:otherwise>
+</xsl:choose>
+<xsl:if test="marc:subfield[@code='e']"> :
+<xsl:value-of select="marc:subfield[@code='e']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='f']"> /
+<xsl:value-of select="marc:subfield[@code='f']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='d']"> ,
+<xsl:value-of select="marc:subfield[@code='d']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='p']"> ,
+<xsl:value-of select="marc:subfield[@code='p']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='v']">,
+<xsl:value-of select="marc:subfield[@code='v']"/>
+</xsl:if>
+</span>
+</xsl:for-each>
+</xsl:template>
+
+
+<!--Titre de serie non autorité 461-->
+<xsl:template name="tag_461bis">
+<xsl:variable name="type_doc" select="marc:datafield[@tag=099]/marc:subfield[@code='t']"/>
+<xsl:for-each select="marc:datafield[@tag=461]">
+<xsl:call-template name="addClassRtl" />
+<xsl:choose>
+<!--si notice d'article-->
+<xsl:when test="contains($type_doc,'Article') and marc:subfield[@code='9']">
+<li style="list-style-type: none;">
+<strong>Titre du périodique : </strong>
+<xsl:if test="marc:subfield[@code='a']">
+<xsl:value-of select="marc:subfield[@code='a']"/><xsl:text> , </xsl:text>
+</xsl:if>
+<xsl:element name="a"><xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=sn&amp;q=<xsl:value-of select="marc:subfield[@code='9']
+"/>
+</xsl:attribute> <xsl:value-of select="marc:subfield[@code='t']"/></xsl:element>
+<xsl:element name="a"><xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=index-title-serie,phr&amp;q=<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:attribute> - Voir les autres articles</xsl:element>
+</li>
+</xsl:when>
+<!--sinon-->
+<xsl:otherwise>
+<li style="list-style-type: none;">
+<strong>Titre de la série : </strong>
+<xsl:if test="marc:subfield[@code='a']">
+<xsl:value-of select="marc:subfield[@code='a']"/><xsl:text> , </xsl:text>
+</xsl:if>
+<xsl:element name="a"><xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=index-title-serie,phr&amp;q=<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:attribute> <xsl:value-of select="marc:subfield[@code='t']"/></xsl:element>
+</li>
+</xsl:otherwise>
+</xsl:choose>
+<xsl:if test="marc:datafield[@tag=461]/marc:subfield[@code='e']"> :
+<xsl:value-of select="marc:datafield[@tag=461]/marc:subfield[@code='e']"/>
+</xsl:if>
+<xsl:if test="marc:datafield[@tag=461]/marc:subfield[@code='f']"> /
+<xsl:value-of select="marc:datafield[@tag=461]/marc:subfield[@code='f']"/>
+</xsl:if>
+<xsl:if test="marc:datafield[@tag=461]/marc:subfield[@code='d']"> ,
+<xsl:value-of select="marc:datafield[@tag=461]/marc:subfield[@code='d']"/>
+</xsl:if>
+<xsl:if test="marc:datafield[@tag=461]/marc:subfield[@code='p']"> ,
+<xsl:value-of select="marc:datafield[@tag=461]/marc:subfield[@code='p']"/>
+</xsl:if>
+<xsl:if test="marc:datafield[@tag=461]/marc:subfield[@code='v']">,
+<xsl:value-of select="marc:datafield[@tag=461]/marc:subfield[@code='v']"/>
+</xsl:if>
+<xsl:if test="marc:datafield[@tag=461]/marc:subfield[@code='w']"> -
+<xsl:value-of select="marc:datafield[@tag=461]/marc:subfield[@code='w']"/>
+</xsl:if>
+</xsl:for-each>	
+</xsl:template>
+
+<!--Titre dépouillé 463-->
+<xsl:template name="tag_463">
+<xsl:for-each select="marc:datafield[@tag=463][1]">
+<span class="results_summary">
+<span class="label">Titre dépouillé : </span>
+<xsl:call-template name="addClassRtl" />
+<xsl:if test="marc:subfield[@code='a']">
+<xsl:value-of select="marc:subfield[@code='a']"/><xsl:text>. </xsl:text>
+</xsl:if>
+<xsl:choose>
+<xsl:when test="marc:subfield[@code='9']">
+<xsl:element name="a"><xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Local-number,phr&amp;q=<xsl:value-of select="marc:subfield[@code='9']"/>
+</xsl:attribute> <xsl:value-of select="marc:subfield[@code='t']"/></xsl:element>
+</xsl:when>
+<xsl:otherwise>
+<xsl:element name="a"><xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=index-title-article,phr&amp;q=<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:attribute> <xsl:value-of select="marc:subfield[@code='t']"/></xsl:element>
+</xsl:otherwise>
+</xsl:choose>
+<xsl:if test="marc:subfield[@code='e']"> :
+<xsl:value-of select="marc:subfield[@code='e']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='f']"> /
+<xsl:value-of select="marc:subfield[@code='f']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='d']"> ,
+<xsl:value-of select="marc:subfield[@code='d']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='p']"> ,
+<xsl:value-of select="marc:subfield[@code='p']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='v']">,
+<xsl:value-of select="marc:subfield[@code='v']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='w']"> -
+<xsl:value-of select="marc:subfield[@code='w']"/>
+</xsl:if>
+</span>
+</xsl:for-each>
+</xsl:template>
+
+<!--Public 995q-->
+<xsl:template name="public">
+<xsl:if test="marc:datafield[@tag=995]/marc:subfield[@code='q']">
+<span class="results_summary">
+<span class="label">Public :</span>
+<xsl:for-each select="marc:datafield[@tag=995]/marc:subfield[@code='q']">
+<xsl:if test="position() = 1">
+<xsl:value-of select="." />
+</xsl:if></xsl:for-each>
+</span> 
+</xsl:if>
+</xsl:template>
+
+<!--Fonds 995h-->
+<xsl:template name="fonds">
+<xsl:if test="marc:datafield[@tag=995]/marc:subfield[@code='h']">
+<span class="results_summary">
+<span class="label">Fonds : </span>
+<xsl:for-each select="marc:datafield[@tag=995]/marc:subfield[@code='h']">
+<xsl:if test="position() = 1">
+<xsl:value-of select="." />
+</xsl:if></xsl:for-each>
+</span>
+</xsl:if>
+</xsl:template>
+
+<!--Nouveauté 995$B-->
+<xsl:template name="nouveaute">
+<xsl:if test="marc:datafield[@tag=995]/marc:subfield[@code='B']">
+<xsl:for-each select="marc:datafield[@tag=995]/marc:subfield[@code='B']">
+<xsl:if test="position() = 1">
+<xsl:element name="img">
+<xsl:attribute name="size">14px</xsl:attribute>
+<xsl:attribute name="src">/public/images/nouveau.png</xsl:attribute><xsl:attribute name="title">Nouveauté</xsl:attribute></xsl:element>
+</xsl:if></xsl:for-each>
+</xsl:if>
+</xsl:template>
+
+<xsl:template name="tag_462_ppn">
+<xsl:variable name="ppn" select="marc:controlfield[@tag=009]"/>
+<xsl:for-each select="marc:controlfield[@tag=009]">
+<span class="results_summary">
+<span class="label">Liste des unités dépouillées : </span>
+
+<xsl:call-template name="addClassRtl" />
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=kw,phr&amp;q=<xsl:value-of select="$ppn"/>
+</xsl:attribute>Voir titres</xsl:element>
+</span>
+</xsl:for-each>
+</xsl:template>
+
+<xsl:template name="tag_462">
+<xsl:for-each select="marc:datafield[@tag=090][1]">
+<span class="results_summary">
+<span class="label">Liste des unités dépouillées : </span>
+<xsl:call-template name="addClassRtl" />
+<xsl:if test="marc:subfield[@code='a']">
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=index-lien-desc,phr&amp;q=<xsl:value-of select="marc:subfield[@code='a'][1]"/>
+</xsl:attribute>Voir titres</xsl:element>
+</xsl:if>
+</span>
+</xsl:for-each>
+</xsl:template>
+
+<xsl:template name="tag_4xx">
+<xsl:param name="tag" />
+<xsl:param name="label" />
+<xsl:if test="marc:datafield[@tag=$tag]">
+<span class="results_summary">
+<span class="label"><xsl:value-of select="$label" /> : </span>
+<xsl:for-each select="marc:datafield[@tag=$tag]">
+<xsl:call-template name="addClassRtl" />
+<xsl:choose>
+<xsl:when test="marc:subfield[@code='9']">
+<xsl:element name="a"><xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=Local-number,phr&amp;q=<xsl:value-of select="marc:subfield[@code='9']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='t']"/></xsl:element>
+</xsl:when>
+<xsl:when test="marc:subfield[@code='0']">
+<xsl:element name="a"><xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=kw,phr&amp;q=<xsl:value-of select="marc:subfield[@code='0']"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='t']"/></xsl:element>
+</xsl:when>
+<xsl:otherwise>
+<xsl:value-of select="marc:subfield[@code='t']"/>
+</xsl:otherwise>
+</xsl:choose>
+<xsl:if test="marc:subfield[@code='c']"> : <xsl:value-of select="marc:subfield[@code='c']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='d']"> ; <xsl:value-of select="marc:subfield[@code='d']"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='e'][1]"> - <xsl:value-of select="marc:subfield[@code='e'][1]"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='f'][1]"> - <xsl:value-of select="marc:subfield[@code='f'][1]"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='g'][1]"> - <xsl:value-of select="marc:subfield[@code='g'][1]"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='h'][1]"> - <xsl:value-of select="marc:subfield[@code='h'][1]"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='i'][1]"> - <xsl:value-of select="marc:subfield[@code='i'][1]"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='l'][1]"> - <xsl:value-of select="marc:subfield[@code='l'][1]"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='v'][1]"> , <xsl:value-of select="marc:subfield[@code='v'][1]"/>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='x']">,
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=ns&amp;q=<xsl:value-of select="marc:subfield[@code='x'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='x'][1]"/></xsl:element>
+</xsl:if>
+<xsl:if test="marc:subfield[@code='y']">,
+<xsl:element name="a">
+<xsl:attribute name="href">
+/cgi-bin/koha/opac-search.pl?idx=nb&amp;q=<xsl:value-of select="marc:subfield[@code='y'][1]"/>
+</xsl:attribute><xsl:value-of select="marc:subfield[@code='y'][1]"/></xsl:element>
+</xsl:if>
+<xsl:if test="not (position() = last())">
+<xsl:text> ; </xsl:text>
+</xsl:if>
+</xsl:for-each>
+</span>
+</xsl:if>
+</xsl:template>
+
+ <xsl:template name="tag_onesubject">
+ <xsl:choose>
+ <xsl:when test="marc:subfield[@code=9]">
+ <xsl:for-each select="marc:subfield">
+ <xsl:if test="@code='9'">
+ <xsl:variable name="start" select="position()"/>
+ <xsl:variable name="ends">
+ <xsl:for-each select="../marc:subfield[position() &gt; $start]">
+ <xsl:if test="@code=9">
+ <xsl:variable name="end" select="position() + $start"/>
+ <xsl:value-of select="$end"/>
+ <xsl:text>,</xsl:text>
+ </xsl:if>
+ </xsl:for-each>
+ </xsl:variable>
+ <xsl:variable name="end">
+ <xsl:choose>
+ <xsl:when test="string-length($ends) > 0">
+ <xsl:value-of select="substring-before($ends,',')"/>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:text>1000</xsl:text>
+ </xsl:otherwise>
+ </xsl:choose>
+ </xsl:variable>
+ <xsl:variable name="display">
+ <xsl:for-each select="../marc:subfield[position() &gt; $start and position() &lt; $end and @code!=2 and @code!=3]">
+ <xsl:value-of select="."/>
+ <xsl:if test="not(position()=last())">
+ <xsl:text>, </xsl:text>
+ </xsl:if>
+ </xsl:for-each>
+ </xsl:variable>
+ <a>
+ <xsl:attribute name="href">
+ <xsl:text>/cgi-bin/koha/opac-search.pl?q=an:</xsl:text>
+ <xsl:value-of select="."/>
+ </xsl:attribute>
+ <xsl:choose>
+ <xsl:when test="string-length($display) &gt; 0">
+ <xsl:call-template name="chopPunctuation">
+ <xsl:with-param name="chopString">
+ <xsl:value-of select="$display"/>
+ </xsl:with-param>
+ </xsl:call-template>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:value-of select="."/>
+ </xsl:otherwise>
+ </xsl:choose>
+ </a>
+ <xsl:variable name="ncommas"
+ select="string-length($ends) - string-length(translate($ends, ',', ''))" />
+ <xsl:if test="$ncommas &gt; 1">
+ <xsl:text> -- </xsl:text>
+ </xsl:if>
+ </xsl:if>
+ </xsl:for-each>
+ </xsl:when>
+ <xsl:when test="marc:subfield[@code='a']">
+ <a>
+ <xsl:attribute name="href">
+ <xsl:text>/cgi-bin/koha/opac-search.pl?q=su:</xsl:text>
+ <xsl:value-of select="marc:subfield[@code='a']"/>
+ </xsl:attribute>
+ <xsl:call-template name="chopPunctuation">
+ <xsl:with-param name="chopString">
+ <xsl:call-template name="subfieldSelect">
+ <xsl:with-param name="codes">abcdfijkmnpvxyz</xsl:with-param>
+ <xsl:with-param name="subdivCodes">ijknpxyz</xsl:with-param>
+ <xsl:with-param name="subdivDelimiter">-- </xsl:with-param>
+ </xsl:call-template>
+ </xsl:with-param>
+ </xsl:call-template>
+ </a>
+ </xsl:when>
+ <xsl:otherwise/>
+ </xsl:choose>
+ <xsl:if test="not(position()=last())">
+ <xsl:text> | </xsl:text>
+ </xsl:if>
+ </xsl:template>
+
+ <xsl:template name="tag_subject">
+ <xsl:param name="tag" />
+ <xsl:param name="label" />
+ <xsl:param name="spanclass" />
+ <xsl:if test="marc:datafield[@tag=$tag]">
+ <span class="results_summary subjects {$spanclass}">
+ <span class="label">
+ <xsl:value-of select="$label"/>
+ <xsl:text> : </xsl:text>
+ </span>
+ <span class="value">
+ <xsl:for-each select="marc:datafield[@tag=$tag]">
+ <xsl:call-template name="tag_onesubject">
+ </xsl:call-template>
+ </xsl:for-each>
+ </span>
+ </span>
+ </xsl:if>
+ </xsl:template>
+
+
+ <xsl:template name="tag_71x">
+ <xsl:param name="tag" />
+ <xsl:param name="label" />
+ <xsl:param name="spanclass" />
+ <xsl:if test="marc:datafield[@tag=$tag]">
+ <span class="results_summary author {$spanclass}">
+ <span class="label">
+ <xsl:value-of select="$label" />
+ <xsl:text>: </xsl:text>
+ </span>
+ <span class="value">
+ <xsl:for-each select="marc:datafield[@tag=$tag]">
+ <a>
+ <xsl:choose>
+ <xsl:when test="marc:subfield[@code=9]">
+ <xsl:attribute name="href">/cgi-bin/koha/opac-search.pl?q=an:<xsl:value-of select="marc:subfield[@code=9]"/></xsl:attribute>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:attribute name="href">/cgi-bin/koha/opac-search.pl?q=au:<xsl:value-of select="marc:subfield[@code='a']"/><xsl:text> </xsl:text><xsl:value-of select="marc:subfield[@code='b']"/></xsl:attribute>
+ </xsl:otherwise>
+ </xsl:choose>
+ <xsl:if test="marc:subfield[@code='a']">
+ <xsl:value-of select="marc:subfield[@code='a']"/>
+ </xsl:if>
+ <xsl:if test="marc:subfield[@code='b']">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='b']"/>
+ </xsl:if>
+ <xsl:if test="marc:subfield[@code='b'][2]">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='b'][2]"/>
+ </xsl:if>
+ <xsl:if test="marc:subfield[@code='b'][3]">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='b'][3]"/>
+ </xsl:if>
+ <xsl:if test="marc:subfield[@code='c']">
+ <xsl:text>. </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='c']"/>
+ </xsl:if>
+<xsl:choose>
+<xsl:when test="(marc:subfield[@code='d']) and (marc:subfield[@code='f']) and (marc:subfield[@code='e'])">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:text> ; </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:text> ; </xsl:text>
+<xsl:value-of select="marc:subfield[@code='f']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='d']) and (marc:subfield[@code='f'])">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:text> ; </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='f']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='d']) and (marc:subfield[@code='e'])">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+<xsl:text> ; </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='e']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+<xsl:when test="(marc:subfield[@code='e']) and (marc:subfield[@code='f'])">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='e']"/>
+<xsl:text> ; </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='f']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+<xsl:when test="marc:subfield[@code='d']">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='d']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+<xsl:when test="marc:subfield[@code='e']">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='e']"/>
+ <xsl:text> ) </xsl:text>
+</xsl:when>
+</xsl:choose>
+<xsl:if test="marc:subfield[@code='4']">
+ <xsl:text> ( </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='4']"/>
+<xsl:text> ) </xsl:text>
+ </xsl:if>
+ </a>
+ <xsl:if test="not (position() = last())">
+ <xsl:text> ; </xsl:text>
+ </xsl:if>
+ </xsl:for-each>
+ </span></span>
+ </xsl:if>
+ </xsl:template>
+
+
+ <xsl:template name="tag_7xx">
+ <xsl:param name="tag" />
+ <xsl:param name="label" />
+ <xsl:param name="spanclass" />
+ <xsl:if test="marc:datafield[@tag=$tag]">
+ <span class="results_summary author {$spanclass}">
+ <span class="label">
+ <xsl:value-of select="$label" />
+ <xsl:text> : </xsl:text>
+ </span>
+ <span class="value">
+ <xsl:for-each select="marc:datafield[@tag=$tag]">
+ <a>
+ <xsl:choose>
+ <xsl:when test="marc:subfield[@code=9]">
+ <xsl:attribute name="href">
+ <xsl:text>/cgi-bin/koha/opac-search.pl?q=an:</xsl:text>
+ <xsl:value-of select="marc:subfield[@code=9]"/>
+ </xsl:attribute>
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:attribute name="href">
+ <xsl:text>/cgi-bin/koha/opac-search.pl?q=au:</xsl:text>
+ <xsl:value-of select="marc:subfield[@code='a']"/>
+ <xsl:text> </xsl:text>
+ <xsl:value-of select="marc:subfield[@code='b']"/>
+ </xsl:attribute>
+ </xsl:otherwise>
+ </xsl:choose>
+ <xsl:for-each select="marc:subfield[@code='a' or @code='b' or @code='4' or @code='c' or @code='d' or @code='f' or @code='g' or @code='p']">
+ <xsl:choose>
+ <xsl:when test="@code='9'">
+ </xsl:when>
+ <xsl:otherwise>
+ <xsl:value-of select="."/>
+ </xsl:otherwise>
+ </xsl:choose>
+ <xsl:if test="not(position() = last())">
+ <xsl:text>, </xsl:text>
+ </xsl:if>
+ </xsl:for-each>
+ </a>
+ <xsl:if test="not(position() = last())">
+ <span style="padding: 3px;">
+ <xsl:text>;</xsl:text>
+ </span>
+ </xsl:if>
+ </xsl:for-each>
+ </span>
+ </span>
+ </xsl:if>
+ </xsl:template>
+
+<xsl:template name="RCR">
+  <xsl:param name="code"/>
+  <xsl:choose>
+    <xsl:when test="$code='xxxxxxxxx'">Bibliothèque xxxxxxxxx</xsl:when>
+    <xsl:when test="$code='yyyyyyyyy'">Bibliothèque yyyyyyyyy</xsl:when>
+    <xsl:otherwise><xsl:value-of select="$code"/></xsl:otherwise>
+  </xsl:choose>
+</xsl:template>
+
+</xsl:stylesheet>


### PR DESCRIPTION
Voici les XSLT que nous utilisons dans notre paramétrage standard.
Actuellement c'est pour Koha 20.11 mais c'est normalement fonctionnel au moins à partir de 18.11.

Enjoy :smiley_cat: 